### PR TITLE
Bump Nokogiri -> 1.8.2 to fix security vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,9 +182,9 @@ GEM
     minitest (5.10.3)
     multipart-post (2.0.0)
     net-dns (0.8.0)
-    nokogiri (1.8.1)
+    nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
-    nokogiri (1.8.1-x64-mingw32)
+    nokogiri (1.8.2-x64-mingw32)
       mini_portile2 (~> 2.3.0)
     octokit (4.7.0)
       sawyer (~> 0.8.0, >= 0.5.3)
@@ -222,4 +222,4 @@ DEPENDENCIES
   jekyll-paginate
 
 BUNDLED WITH
-   1.15.4
+   1.16.1


### PR DESCRIPTION
... reported by GitHub.

See https://nvd.nist.gov/vuln/detail/CVE-2017-18258 for details.