### PR TITLE
Ensure that Google Analytics pageview event is submitted for landing pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,6 +8,8 @@ githuburl: https://github.com/SpineEventEngine/SpineEventEngine.github.io/
 twitter_username: SpineEngine
 github_username: SpineEventEngine
 
+google_analytics_tag: UA-71822190-1
+
 # Gems
 plugins: [jekyll-paginate]
 

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -14,7 +14,7 @@
           m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-      ga('create', 'UA-71822190-1', 'auto');
+      ga('create', '{{ site.google_analytics_tag }}', 'auto');
       ga('send', 'pageview');
   </script>
 

--- a/alexander/index.html
+++ b/alexander/index.html
@@ -1,11 +1,13 @@
 ---
-layout: default
-group: 'navigation'
-title: Alexander Yevsyukov
-bodyclass: about
-headline: 'Alexander Yevsyukov'
 ---
 <script type="text/javascript">
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+    ga('create', '{{ site.google_analytics_tag }}', 'auto');
+    ga('send', 'pageview');
     document.location = "/";
 </script>
 

--- a/jee18/index.html
+++ b/jee18/index.html
@@ -1,11 +1,13 @@
 ---
-layout: default
-group: 'navigation'
-title: JEEConf 2018
-bodyclass: about
-headline: 'JEEConf 2018'
 ---
 <script type="text/javascript">
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+    ga('create', '{{ site.google_analytics_tag }}', 'auto');
+    ga('send', 'pageview');
     document.location = "/";
 </script>
 


### PR DESCRIPTION
In this changeset we make sure that GA analytic data is submitted **before** a user is taken away from the spine.io/jee18 and spine.io/alexander pages to the site homepage. 

Also the GA tag is now a site-level variable to reuse across places.