### PR TITLE
Simplify gathering stats for JEE18 landing pages

### DIFF
--- a/alexander/index.html
+++ b/alexander/index.html
@@ -1,13 +1,6 @@
 ---
 ---
 <script type="text/javascript">
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-    ga('create', '{{ site.google_analytics_tag }}', 'auto');
-    ga('send', 'pageview');
-    document.location = "/";
+    document.location = "/?ref=alexander";
 </script>
 

--- a/jee18/index.html
+++ b/jee18/index.html
@@ -1,13 +1,6 @@
 ---
 ---
 <script type="text/javascript">
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-    ga('create', '{{ site.google_analytics_tag }}', 'auto');
-    ga('send', 'pageview');
-    document.location = "/";
+    document.location = "/?ref=jee18";
 </script>
 


### PR DESCRIPTION
Previously the GA script was duplicated on each of the JEE18 landing pages. Also, even with the submission of the pageview before redirecting users to the homepage, the pageviews sometimes were not counted.

Now we count landing on the main page using URL parameters instead of submitting a separate pageview from each of the landing pages. Also a duplication of GA script is eliminated. 

Simpler is better.