### PR TITLE
Fix language in Naming Conventions guide

### DIFF
--- a/docs/guides/naming-conventions.md
+++ b/docs/guides/naming-conventions.md
@@ -60,7 +60,7 @@ Similarly to events, rejections are defined in files ending with `rejections.pro
   * `customer_rejections.proto`.
 
 For each aggregate you are likely to have all the three kinds of files because a command leads to
-an event, and it's likely there are conditions under which a command cannot be performed.
+an event, and it's likely there are conditions under which a command cannot be handled.
 
 ### Entity states
 

--- a/docs/guides/naming-conventions.md
+++ b/docs/guides/naming-conventions.md
@@ -32,9 +32,9 @@ files defining the data model of the corresponding Bounded Context.
 ### Command definitions
 
 Commands are defined in a file which names end with `commands.proto`. 
-It can be simply `commands.proto`, but usually there are many commands that are handled by 
-different aggregates. So, it's convenient to name such files after the type of the target
-aggregate: 
+It can be simply `commands.proto`, but usually commands are handled by different entities. 
+So, it's convenient to name such a file after the type of the target entity, 
+for instance, an aggregate: 
 
  * `blog_commands.proto` 
  * `order_commands.proto` 


### PR DESCRIPTION
This PR improves language on naming command files.