### PR TITLE
Improve conventions guide

### DIFF
--- a/docs/guides/naming-conventions.md
+++ b/docs/guides/naming-conventions.md
@@ -236,15 +236,26 @@ a sub-package called `server`, with sub-packages for corresponding entity types:
 
 ### Entities 
 
-#### Aggregate
+When naming entities we find it natural to start with a name of astate cass and then
+add a suffix which tells the type of the entity:
 
-<!-- TODO:2018-11-21:alexander.yevsyukov: Write text. --> 
+  * `ProjectAggregate`
+  * `OrderProcessManager`
+  * `TaskItemProjection`  
 
-#### Process Manager
-
-#### Projection
-
+The suffix helps when observing together with other entities in a package. For process managers
+it may be enough to have the `Process` suffix, dropping `Manager`, which frequently worked 
+for us too.
+  
 #### Repositories
+
+We recommend _not_ using a type infix for naming repository classes. Alphabetical sorting would
+make a repository class be next to an entity class. And you would not deal much with repository 
+classes anyway. So, it's just `SomethingRepository`, rather than `SomethingAggregateRepository`:
+
+  * `ProjectRepository`
+  * `OrderRepository`
+  * `TaskItemRepository` 
 
 ### Bounded Contexts
 

--- a/docs/guides/naming-conventions.md
+++ b/docs/guides/naming-conventions.md
@@ -7,10 +7,9 @@ sidenav: doc-side-guides-nav.html
 type: markdown
 ---
 
-<p>This document covers the naming conventions used in the Spine framework, and in applications 
-based on the framework that we wrote. Some of these contentions are used by the framework and 
-code generation tools. Others are our recommendations that we find useful for naming
-and structuring the code.</p>
+<p>This document covers the naming conventions for the code. Some of these contentions are used by 
+the framework and code generation, and as such are required. Others are our recommendations that 
+we find useful for making things clear and structuring the code.</p>
 
 ## Proto files
 

--- a/docs/guides/naming-conventions.md
+++ b/docs/guides/naming-conventions.md
@@ -236,7 +236,7 @@ a sub-package called `server`, with sub-packages for corresponding entity types:
 
 ### Entities 
 
-When naming entities we find it natural to start with a name of astate cass and then
+When naming entities we find it natural to start with a name of a state class and then
 add a suffix which tells the type of the entity:
 
   * `ProjectAggregate`

--- a/docs/guides/naming-conventions.md
+++ b/docs/guides/naming-conventions.md
@@ -243,9 +243,11 @@ add a suffix which tells the type of the entity:
   * `OrderProcessManager`
   * `TaskItemProjection`  
 
-The suffix helps when observing together with other entities in a package. For process managers
-it may be enough to have the `Process` suffix, dropping `Manager`, which frequently worked 
-for us too.
+The suffix helps when observing together with other entities in a package. 
+
+For process managers it may be enough to have the `Process` suffix, dropping `Manager`, 
+which frequently worked for us too. Other options for suffixes are `Pm` or `Procman`. 
+It would be a good idea to decide on such a suffix as a team standard, before you start coding.  
   
 #### Repositories
 

--- a/docs/prior-art.md
+++ b/docs/prior-art.md
@@ -28,7 +28,7 @@ automatic **code generation** for multiple application clients.
 It is reached by using [Protocol Buffers](https://developers.google.com/protocol-buffers/docs/overview).
 
 When creating an Event Sourcing application, you need to write classes for commands, events, 
-command handlers, aggregates, aggregate repository, DTOs etc.
+command handlers, aggregates, aggregate repositories, DTOs etc.
 And if your organization wants an application on, let’s say, a couple of mobile platforms,
 you would have to add a lot of work to deliver data to each client application.
 So you need to make your code work on another platform by writing it in another language *manually*,

--- a/docs/prior-art.md
+++ b/docs/prior-art.md
@@ -38,7 +38,7 @@ Json in the client apps.
 Using [Protobuf](https://developers.google.com/protocol-buffers/docs/overview) for formulating 
 the business domain allows us to make this language 
 [ubiquitous](http://martinfowler.com/bliki/UbiquitousLanguage.html) not only in human interaction, 
-but in communication of computing devices, too.
+but in communication of computing devices too.
 
 **Immutability** is another major concept we follow.
 Spine uses typed commands and events. Having commands and events as first class citizens in the 
@@ -47,7 +47,8 @@ forth with Json gives some performance advantage at the same time.
 
 We are greatly inspired by [Redux](http://redux.js.org) — one of the most exciting things happening
 in JavaScript at the moment. It stands out from the landscape of libraries and frameworks by 
-getting so many things absolutely right: a simple, predictable state model; an emphasis on functional programming and immutable data.
+getting so many things absolutely right: a simple, predictable state model; an emphasis on functional
+programming and immutable data.
 
 In Spine Event Engine we combined all of our experience and observations of the best-breed market
 products and solutions like [Axon](http://www.axonframework.org/), [Spring](https://spring.io/), 

--- a/docs/prior-art.md
+++ b/docs/prior-art.md
@@ -8,36 +8,80 @@ type: markdown
 
 # Prior Art
 
-The demands for software projects increase rapidly as time progresses. So does the scope of architecture approaches to meet these needs.
-This section will give you an overview of the concepts and implementations Spine has inherited, while bringing some important differences into play.
+The demands for software projects increase rapidly as time progresses. 
+So does the scope of architecture approaches to meet these needs.
+This section will give you an overview of the concepts and implementations Spine has inherited, 
+while bringing some important differences into play.
 
-Spine is created for applications that follow the [CQRS](http://martinfowler.com/bliki/CQRS.html)  and [Event Sourcing](http://martinfowler.com/eaaDev/EventSourcing.html) architectural patterns.
+Spine is created for applications that follow the [CQRS](http://martinfowler.com/bliki/CQRS.html) 
+and [Event Sourcing](http://martinfowler.com/eaaDev/EventSourcing.html) architectural patterns.
 
-Spine didn’t appear out of the blue. While working on our own CQRS/ES based projects we were amazed how much manual effort is spent on creating events and commands, delivering events and data to the web and mobile clients. It takes time, does not require much creativity from a developer, whilst this energy could have been spent on productive [Event Storming](http://ziobrando.blogspot.com/2013/11/introducing-event-storming.html), detailing the Domain model and so on. Attempts to address this issue led to the Spine vision.
+Spine didn’t appear out of the blue. While working on our own CQRS/ES based projects we were 
+amazed how much manual effort is spent on creating events and commands, delivering events and data
+to the web and mobile clients. It takes time, does not require much creativity from a developer,
+whilst this energy could have been spent on productive 
+[Event Storming](http://ziobrando.blogspot.com/2013/11/introducing-event-storming.html), 
+detailing the Domain model and so on. Attempts to address this issue led to the Spine vision.
 
-A major addition Spine brings to the existent variety of tools, libraries, and frameworks is automatic **code generation** for multiple application clients. It is reached by using [Protocol Buffers](https://developers.google.com/protocol-buffers/docs/overview).
+A major addition Spine brings to the existent variety of tools, libraries, and frameworks is 
+automatic **code generation** for multiple application clients. 
+It is reached by using [Protocol Buffers](https://developers.google.com/protocol-buffers/docs/overview).
 
-When creating an Event Sourcing application, you need to write classes for commands, events, command handlers, aggregates, aggregate repository, DTOs etc.
-And if your organization wants an application on, let’s say, a couple of mobile platforms, you would have to add a lot of work to deliver data to each client application.
-So you need to make your code work on another platform by writing it in another language *manually*, or translate it using tools like [J2ObjC](http://j2objc.org/), or resort to using only Json in the client apps.
+When creating an Event Sourcing application, you need to write classes for commands, events, 
+command handlers, aggregates, aggregate repository, DTOs etc.
+And if your organization wants an application on, let’s say, a couple of mobile platforms,
+you would have to add a lot of work to deliver data to each client application.
+So you need to make your code work on another platform by writing it in another language *manually*,
+or translate it using tools like [J2ObjC](http://j2objc.org/), or resort to using only 
+Json in the client apps.
 
-Using [Protobuf](https://developers.google.com/protocol-buffers/docs/overview) for formulating the business domain allows us to make this language [ubiquitous](http://martinfowler.com/bliki/UbiquitousLanguage.html) not only in human interaction, but in communication of computing devices, too.
+Using [Protobuf](https://developers.google.com/protocol-buffers/docs/overview) for formulating 
+the business domain allows us to make this language 
+[ubiquitous](http://martinfowler.com/bliki/UbiquitousLanguage.html) not only in human interaction, 
+but in communication of computing devices, too.
 
 **Immutability** is another major concept we follow.
-Spine uses typed commands and events. Having commands and events as first class citizens in the applications gives a lot of benefits in terms of business logic. Not having to convert back and forth with Json gives some performance advantage at the same time.
+Spine uses typed commands and events. Having commands and events as first class citizens in the 
+applications gives a lot of benefits in terms of business logic. Not having to convert back and 
+forth with Json gives some performance advantage at the same time.
 
-We are greatly inspired by [Redux](http://redux.js.org) — one of the most exciting things happening in JavaScript at the moment. It stands out from the landscape of libraries and frameworks by getting so many things absolutely right: a simple, predictable state model; an emphasis on functional programming and immutable data.
+We are greatly inspired by [Redux](http://redux.js.org) — one of the most exciting things happening
+in JavaScript at the moment. It stands out from the landscape of libraries and frameworks by 
+getting so many things absolutely right: a simple, predictable state model; an emphasis on functional programming and immutable data.
 
-In Spine Event Engine we combined all of our experience and observations of the best-breed market products and solutions like [Axon](http://www.axonframework.org/), [Spring](https://spring.io/), [Event Store](https://geteventstore.com/), [InfluxDB](https://influxdata.com/), [Apache Zest](https://zest.apache.org/) and many others. Spine has yet to find its own niche.
+In Spine Event Engine we combined all of our experience and observations of the best-breed market
+products and solutions like [Axon](http://www.axonframework.org/), [Spring](https://spring.io/), 
+[Event Store](https://geteventstore.com/), [InfluxDB](https://influxdata.com/), 
+[Apache Zest](https://zest.apache.org/) and many others. 
+Spine has yet to find its own niche.
 
- Spine probably won’t be the best fit for trading or highly loaded applications, where, for example, [LMAX](https://www.lmax.com/) does an excellent job. Our motivation is to make development of modern applications easier and more efficient, and to offer a set of practical solutions to bring this into life with a corresponding approach and terminology.
+Spine probably won’t be the best fit for trading or highly loaded applications, where, for example,
+[LMAX](https://www.lmax.com/) does an excellent job. Our motivation is to make development of
+modern applications easier and more efficient, and to offer a set of practical solutions to bring
+this into life with a corresponding approach and terminology.
 
-In terminology we heavily lean on [Domain-Driven Design (DDD)](https://en.wikipedia.org/wiki/Domain-driven_design) and the [“Big Blue Book”](http://www.amazon.com/Domain-Driven-Design-Tackling-Complexity-Software/dp/0321125215) by Eric Evans. We learned a lot from the book [“CQRS Journey”](https://msdn.microsoft.com/en-us/library/jj554200.aspx) by Microsoft, and our choice of the term “Process Manager” over the commonly used “Saga” is based on the experience of Microsoft engineers. The “Process Manager” pattern was first defined and brought into common vocabulary by Kyle Brown and Bobby Woolf under the guidance of Martin Fowler in the book [“Enterprise Integration Patterns”](http://www.enterpriseintegrationpatterns.com/patterns/messaging/ProcessManager.html).
+In terminology we heavily lean on [Domain-Driven Design (DDD)](https://en.wikipedia.org/wiki/Domain-driven_design)
+and the [“Big Blue Book”](http://www.amazon.com/Domain-Driven-Design-Tackling-Complexity-Software/dp/0321125215) 
+by Eric Evans.
 
-Another great resource on object-oriented design worth mentioning here is [“Patterns of Enterprise Application Architecture”](http://www.martinfowler.com/books/eaa.html) by Martin Fowler. Many modern frameworks implement these patterns behind the scenes, and so does Spine.
+We learned a lot from the book [“CQRS Journey”](https://msdn.microsoft.com/en-us/library/jj554200.aspx)
+by Microsoft, and our choice of the term “Process Manager” over the commonly used “Saga” is 
+based on the experience of Microsoft engineers. 
+The “Process Manager” pattern was first defined and brought into common vocabulary by Kyle Brown
+and Bobby Woolf under the guidance of Martin Fowler in the book 
+[“Enterprise Integration Patterns”](http://www.enterpriseintegrationpatterns.com/patterns/messaging/ProcessManager.html).
+
+Another great resource on object-oriented design worth mentioning here is 
+[“Patterns of Enterprise Application Architecture”](http://www.martinfowler.com/books/eaa.html) 
+by Martin Fowler. Many modern frameworks implement these patterns behind the scenes, and so does Spine.
 But as [Martin Fowler](http://www.martinfowler.com/books/eaa.html) notes:
->Frameworks still require you to make decisions about how to use them, and knowing the underlying patterns is essential if you are to make wise choices.
 
-Systems built on top of Spine framework are flexible, loosely-coupled, scalable and open to change. Here we should thank [Reactive Manifesto](http://www.reactivemanifesto.org/), which became one the corner stones and drivers of the Spine philosophy.
+ >Frameworks still require you to make decisions about how to use them, 
+ >and knowing the underlying patterns is essential if you are to make wise choices.
 
-We are yet at the beginning of our journey of using Spine in the wild. Join us and share how it goes!
+Systems built on top of Spine framework are flexible, loosely-coupled, scalable and open to change.
+Here we should thank [Reactive Manifesto](http://www.reactivemanifesto.org/), 
+which became one the corner stones and drivers of the Spine philosophy.
+
+We are yet at the beginning of our journey of using Spine in the wild.
+Join us and share how it goes!

--- a/docs/prior-art.md
+++ b/docs/prior-art.md
@@ -17,7 +17,7 @@ Spine is created for applications that follow the [CQRS](http://martinfowler.com
 and [Event Sourcing](http://martinfowler.com/eaaDev/EventSourcing.html) architectural patterns.
 
 Spine didn’t appear out of the blue. While working on our own CQRS/ES based projects we were 
-amazed how much manual effort is spent on creating events and commands, delivering events and data
+alarmed at how much manual effort is spent on creating events and commands, delivering events and data
 to the web and mobile clients. It takes time, does not require much creativity from a developer,
 whilst this energy could have been spent on productive 
 [Event Storming](http://ziobrando.blogspot.com/2013/11/introducing-event-storming.html), 


### PR DESCRIPTION
This PR:
  1. adds text on naming entities and repositories;
  2. improves layout of the Prior Art document (which is not included into navigation for now).
