### PR TITLE
Implement `Go to Top` button. And fix small issues.

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -34,3 +34,5 @@ bodyclass: docs
               {{ content }}
           {% endif %}
       {% endif %}
+
+<a onclick="topFunction()" id="go-top-btn" title="Go to Top"><span>Top</span></a>

--- a/_sass/base/_common.scss
+++ b/_sass/base/_common.scss
@@ -111,13 +111,6 @@
   @media(min-width: $tablet){
     display: none;
   }
-
-  &:hover {
-    opacity: 1;
-    background-size: contain;
-    background-color: fade-out($white, .97);
-    border-radius: 50%;
-  }
 }
 
 // Shared

--- a/_sass/modules/_buttons.scss
+++ b/_sass/modules/_buttons.scss
@@ -224,3 +224,43 @@
     text-decoration: none;
   }
 }
+
+#go-top-btn {
+  display: none; /* Hidden by default */
+  position: fixed;
+  text-indent: -9999px;
+  z-index: 9999;
+  bottom: 10px;
+  right: 16px;
+  width: 60px; /* Clickable zone for the mobile — 60px */
+  height: 60px;
+  cursor: pointer;
+  padding: 4px;
+  -webkit-transform: translate3d(0, 0, 0); /* To prevent jumping on scroll in Chrome */
+  transform : translate3d(0, 0, 0);
+
+  &:after {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    margin-left: -20px;
+    margin-top: -20px;
+    content: "";
+    background: rgba($secondBrandColor, .26) url('../img/caret.svg') no-repeat;
+    border-radius: 5px;
+    width: 40px;
+    height: 40px;
+    @include transform(rotate(-180deg));
+    @include transition(all .3s ease-in-out);
+
+    @media (max-width: $tablet) {
+      background-color: rgba($secondBrandColor, .54);
+    }
+  }
+
+  &:hover {
+    &:after {
+      background-color: rgba($mainBrandColor, .87);
+    }
+  }
+}

--- a/_sass/modules/_footer.scss
+++ b/_sass/modules/_footer.scss
@@ -128,6 +128,15 @@ footer {
           transform: rotate(0);
           background-color: transparent;
         }
+
+        &:hover {
+          .mobile-caret-icon {
+            opacity: 1;
+            background-size: contain;
+            background-color: fade-out($white, .97);
+            border-radius: 50%;
+          }
+        }
       }
     }
 

--- a/_sass/modules/_nav.scss
+++ b/_sass/modules/_nav.scss
@@ -161,6 +161,13 @@
           opacity: .54;
           transform: rotate(0);
           background-color: transparent;
+
+          &:hover {
+            opacity: 1;
+            background-size: contain;
+            background-color: fade-out($white, .97);
+            border-radius: 50%;
+          }
         }
       }
 

--- a/_sass/pages/_faq.scss
+++ b/_sass/pages/_faq.scss
@@ -4,10 +4,16 @@
   padding-bottom: 150px;
 
   @media(max-width: $tablet){
+    margin-top: 16px;
     padding-bottom: 64px;
   }
 
   .faq-item {
+
+    @media(max-width: $tablet) {
+      margin-right: 24px;
+    }
+
     .faq-headline {
       display: inline-block;
       margin: 30px 0 5px 0;
@@ -82,9 +88,14 @@
     margin: 16px 0 0 40px;
     padding-bottom: 2px; // It fix jumping items
 
+    @media(max-width: $tablet) {
+      margin-top: 8px;
+    }
+
     ul {
       li {
-        line-height: 32px;
+        line-height: 1.7;
+        margin-bottom: 16px;
       }
     }
   }

--- a/blog/index.html
+++ b/blog/index.html
@@ -77,3 +77,5 @@ headline:  'Spine Blog'
           </div>
         </div>
 </div>
+
+<a onclick="topFunction()" id="go-top-btn" title="Go to Top"><span>Top</span></a>

--- a/js/common.js
+++ b/js/common.js
@@ -25,15 +25,7 @@ $.getScript("/libs/prettify/js/lang-swift.js", function(){});
 $.getScript("/libs/prettify/js/lang-yaml.js", function(){});
 
 
-// Remove class from the parent element when the child is active
-$(function() {
-    if ($('#doc-side-nav-inside a').hasClass('current')) {
-        var element = document.getElementById('side-nav-parent-item');
-        element.classList.remove('current');
-    }
-});
-
-var InitialHeadHeight = $("#header").innerHeight();
+var initialHeadHeight = $("#header").innerHeight();
 var tocNav = $('#toc');
 var initialFooterHeight = $(".footer").innerHeight();
 var headerFixPosition = $(".nav-hero-container").innerHeight();
@@ -42,12 +34,10 @@ var tocNavFixedPosition = 120; // Sticky TOC offset
 
 
 $(function() {
+    switchDocSideNavItems();
     expandItemOnHashChange();
     preventDefaultScroll();
-
-    // Calls the tocify method on your HTML nav.
-    // InitialHeadHeight + 12 (12px — small offset from the header navigation)
-    tocNav.tocify({selectors:"h2, h3, h4", showAndHide: false, scrollTo: InitialHeadHeight+12, extendPage: false});
+    tocTocifySettings();
 });
 
 jQuery(window).on('load', function() {
@@ -61,13 +51,27 @@ window.onhashchange = function() {
 };
 
 window.onscroll = function() {
-    FixToc();
-    FixHead();
-    TocHeight();
+    fixToc();
+    fixHead();
+    tocHeight();
 };
 
+// Remove class from the parent element when the child is active
+function switchDocSideNavItems() {
+    if ($('#doc-side-nav-inside a').hasClass('current')) {
+        var element = document.getElementById('side-nav-parent-item');
+        element.classList.remove('current');
+    }
+}
+
+function tocTocifySettings() {
+    // Calls the tocify method on your HTML nav.
+    // InitialHeadHeight + 12 (12px — small offset from the header navigation)
+    tocNav.tocify({selectors:"h2, h3, h4", showAndHide: false, scrollTo: initialHeadHeight+12, extendPage: false});
+}
+
 // Fix TOC navigation on page while scrolling
-function FixToc() {
+function fixToc() {
     if (tocNav.length > 0) {
         if (window.pageYOffset > tocNavFixedPosition) {
             tocNav.addClass("sticky");
@@ -79,7 +83,7 @@ function FixToc() {
 }
 
 // Animation header on scroll
-function FixHead() {
+function fixHead() {
     var header = $('#header');
     if (header.length > 0) {
         if (window.pageYOffset > headerFixPosition) {
@@ -93,14 +97,14 @@ function FixHead() {
         }
 
         // Return classes to the initial state when the navigation at the top of the page
-        if (window.pageYOffset < InitialHeadHeight) {
+        if (window.pageYOffset < initialHeadHeight) {
             header.removeClass("not-top");
             header.removeClass("unpinned");
         }
     }
 }
 
-function TocHeight() {
+function tocHeight() {
     if (tocNav.length > 0) {
 
         var scrollHeight = $(document).height();
@@ -124,7 +128,7 @@ function TocHeight() {
 // Resize TOC height when window height is changing
 $( window ).resize(function() {
     if ($(window).height() > 600) {
-        TocHeight();
+        tocHeight();
     }
 });
 

--- a/js/common.js
+++ b/js/common.js
@@ -80,7 +80,7 @@ function tocTocifySettings() {
 
 // Fix TOC navigation on page while scrolling
 function fixToc() {
-    if (tocNav.length > 0) {
+    if (tocNav.length) {
         if (window.pageYOffset > tocNavFixedPosition) {
             tocNav.addClass("sticky");
         }
@@ -93,7 +93,7 @@ function fixToc() {
 // Animation header on scroll
 function fixHead() {
     var header = $('#header');
-    if (header.length > 0) {
+    if (header.length) {
         if (window.pageYOffset > headerFixPosition) {
             header.addClass("not-top"); // When navigation below offset
             header.addClass("pinned"); // When navigation below hero section
@@ -113,7 +113,7 @@ function fixHead() {
 }
 
 function tocHeight() {
-    if (tocNav.length > 0) {
+    if (tocNav.length) {
 
         var scrollHeight = $(document).height();
         var windowHeight = $(window).height();
@@ -173,12 +173,12 @@ var goTopBtn = $("#go-top-btn");
 
 // If the cookieChoiceInfo panel exist show “Go to Top” button above this panel
 function ifCookiesExist() {
-    var cookieInfo = $("#cookieChoiceInfo"); // Not working in global variables
+    var cookieInfo = $("#cookieChoiceInfo");
     var cookieAgreeBtn = $("#cookieChoiceDismiss");
     var cookieContainerHeight = cookieInfo.innerHeight();
     var marginBottom = 10; // Bottom margin for the “Go to Top” button
 
-    if(cookieInfo!=null){
+    if(cookieInfo.length){
         $(goTopBtn).css('bottom', cookieContainerHeight + marginBottom);
 
         // If the cookie panel hides on the `Agree` button click leave only initial bottom margin

--- a/js/common.js
+++ b/js/common.js
@@ -38,10 +38,12 @@ $(function() {
     expandItemOnHashChange();
     preventDefaultScroll();
     tocTocifySettings();
+    showScrollTopBtn();
 });
 
 jQuery(window).on('load', function() {
     scrollToAnchor();
+    ifCookiesExist();
 });
 
 // Make functions works immediately on hash change
@@ -54,7 +56,13 @@ window.onscroll = function() {
     fixToc();
     fixHead();
     tocHeight();
+    showScrollTopBtn();
 };
+
+$(window).resize(function() {
+    resizeTocHeightWithWindow();
+    ifCookiesExist();
+});
 
 // Remove class from the parent element when the child is active
 function switchDocSideNavItems() {
@@ -126,11 +134,11 @@ function tocHeight() {
 }
 
 // Resize TOC height when window height is changing
-$( window ).resize(function() {
+function resizeTocHeightWithWindow() {
     if ($(window).height() > 600) {
         tocHeight();
     }
-});
+}
 
 // Expand FAQ item on hash change
 function expandItemOnHashChange() {
@@ -158,4 +166,43 @@ function scrollToAnchor() {
     if ($(anchor).length) {
         $(window).scrollTo($(anchor), 500, {offset: offset});
     }
+}
+
+
+var goTopBtn = $("#go-top-btn");
+
+// If the cookieChoiceInfo panel exist show “Go to Top” button above this panel
+function ifCookiesExist() {
+    var cookieInfo = $("#cookieChoiceInfo"); // Not working in global variables
+    var cookieAgreeBtn = $("#cookieChoiceDismiss");
+    var cookieContainerHeight = cookieInfo.innerHeight();
+    var marginBottom = 10; // Bottom margin for the “Go to Top” button
+
+    if(cookieInfo!=null){
+        $(goTopBtn).css('bottom', cookieContainerHeight + marginBottom);
+
+        // If the cookie panel hides on the `Agree` button click leave only initial bottom margin
+        $(cookieAgreeBtn).click(function(){
+            $(goTopBtn).css('bottom', marginBottom);
+        });
+    }
+
+    else {
+        $(goTopBtn).css('bottom', marginBottom);
+    }
+}
+
+// When the user scrolls down 1500px from the top of the document, show the button ”Go to Top“
+function showScrollTopBtn() {
+    if ($(this).scrollTop() > 1500 ) {
+        $(goTopBtn).show();
+
+    } else {
+        $(goTopBtn).hide();
+    }
+}
+
+// When the user clicks on the button, scroll to the top of the document
+function topFunction() {
+    $("html, body").stop().animate({scrollTop: 0}, 500, 'swing'); return false;
 }


### PR DESCRIPTION
This PR brings `Go to Top` button for the docs pages that appears when the user scrolls down 1500px from the top of the document. To review it better go to the Docs > Guides > Naming Conventions.

Also were fixed:
1. FAQ-section margins;
2. hover states for the collapsible toggles in the mobile header and footer;
3. simplified functions in the `common.js` file.