### PR TITLE
Fixes for issue #141:

### DIFF
--- a/_includes/doc-side-guides-nav.html
+++ b/_includes/doc-side-guides-nav.html
@@ -5,7 +5,7 @@
     <li><a href="{{ site.baseurl }}/docs/guides/project-structure.html" {% if current[3] == 'project-structure.html' %}class='current'{% endif %}>Project Structure</a></li>
     <li><a href="{{ site.baseurl }}/docs/guides/naming-conventions.html" {% if current[3] == 'naming-conventions.html' %}class='current'{% endif %}>Naming Conventions</a></li>
     <li><a href="{{ site.baseurl }}/docs/guides/model-definition.html" {% if current[3] == 'model-definition.html' %}class='current'{% endif %}>Model Definition</a></li>
-
+    <li><a href="{{ site.baseurl }}/docs/guides/validation-user-guide.html" {% if current[3] == 'validation-user-guide.html' %}class='current'{% endif %}>Validation User Guide</a></li>
     <li><h6 class="doc-side-nav-title">Related Guides</h6></li>
     <li><a href="https://developers.google.com/protocol-buffers/docs/overview" target="_blank">Protocol Buffers</a></li>
     <li><a href="https://grpc.io/docs/guides/index.html" target="_blank">gRPC</a></li>

--- a/about/index.html
+++ b/about/index.html
@@ -103,7 +103,7 @@ headline: 'About Spine'
                     <div class="card-content-text">
                         <header class="feature-card-title">Built-in Validation</header>
                         <p>Constraints defined in a business model are
-                            automatically checked for commands, events, and entity states.</p>
+                            automatically checked for commands, events, and entity states using our <a href="docs/guides/validation-user-guide.html">validation approach</a>.</p>
                     </div>
                 </div>
 

--- a/docs/guides/validation-user-guide.md
+++ b/docs/guides/validation-user-guide.md
@@ -1,0 +1,12 @@
+---
+title: Validation User Guide
+headline: Validation User Guide
+bodyclass: docs
+layout: docs
+sidenav: doc-side-guides-nav.html
+type: markdown
+---
+
+<p class="coming-soon">Coming soon...</p>
+
+

--- a/docs/guides/validation-user-guide.md
+++ b/docs/guides/validation-user-guide.md
@@ -6,7 +6,5 @@ layout: docs
 sidenav: doc-side-guides-nav.html
 type: markdown
 ---
-
 <p class="coming-soon">Coming soon...</p>
-
-
+<hr>

--- a/docs/quickstart/java.md
+++ b/docs/quickstart/java.md
@@ -119,7 +119,7 @@ You do not have to make any additional steps to use it in your domain.</p>
  }
   ```
 <p class="note">`vBuilder()` creates a Validating Builder, which checks the values against the validation options when a message is going to be build. The `newBuilder()` creates a standard Builder natively provided by Protobuf. It is safer to always use `vBuilder()`, and it does not make much sense to specify validating options, if `vBuilder()` is not used.
-For example, commands are always validated upon arrival to the server side. We recommend creating a valid command on the client side as it can be too late if the validation is performed upon arrival on the server side.</p> 
+For example, commands are always validated upon arrival to the server side. We recommend creating a valid command on the client side as it can be too late if the validation is performed upon arrival on the server side. For more details, please refer <a href="docs/guides/validation-user-guide.html">Validation User Guide</a>.</p> 
 5. Apply the emitted event:
   ```java
  @Apply

--- a/docs/quickstart/java.md
+++ b/docs/quickstart/java.md
@@ -75,9 +75,8 @@ Keep experimenting with your model. To do so:
      spine.time.LocalDate due_date = 2 [(valid) = true, (required) = true, (when).in = FUTURE];
  }
   ```
-<p class="note">Remember to import `LocalDate` via `import "spine/time/time.proto";`. This type is provided by
-                  the [Spine Time](https://github.com/SpineEventEngine/time) library. You do not have to make any
-                  additional steps to use it in your domain.</p>
+<p class="note">Remember to import `LocalDate` using `import "spine/time/time.proto";` and `import "spine/time/time.options.proto";`. The latter is needed for being able to do `(when).in = FUTURE`. This type is provided by the [Spine Time](https://github.com/SpineEventEngine/time) library. 
+You do not have to make any additional steps to use it in your domain.</p>
 2. Create a new event type in `events.proto`:
   ```proto
  message DueDateAssigned {
@@ -113,12 +112,14 @@ Keep experimenting with your model. To do so:
  @Assign
  DueDateAssigned handle(AssignDueDate command) {
      return DueDateAssignedVBuilder
-             .newBuilder()
+             .vBuilder()
              .setTaskId(command.getTaskId())
              .setDueDate(command.getDueDate())
              .build();
  }
   ```
+<p class="note">`vBuilder()` creates a Validating Builder, which checks the values against the validation options when a message is going to be build. The `newBuilder()` creates a standard Builder natively provided by Protobuf. It is safer to always use `vBuilder()`, and it does not make much sense to specify validating options, if `vBuilder()` is not used.
+For example, commands are always validated upon arrival to the server side. We recommend creating a valid command on the client side as it can be too late if the validation is performed upon arrival on the server side.</p> 
 5. Apply the emitted event:
   ```java
  @Apply
@@ -129,12 +130,11 @@ Keep experimenting with your model. To do so:
 6. In `ClientApp`, extend the `main()` method by posting another command:
   ```java
  AssignDueDate dueDateCommand = AssignDueDateVBuilder
-         .newBuilder()
+         .vBuilder()
          .setTaskId(taskId)
          .setDueDate(LocalDates.of(2038, JANUARY, 19))
          .build();
- commandService.post(requestFactory.command()
-                                   .create(dueDateCommand));
+ commandService.post(requestFactory.command().create(dueDateCommand));
   ```
  and log the updated state:
   ```java


### PR DESCRIPTION
In Java Quick Start guide (quickstart/java.md):
1. Fixed the code alignment in requestFactory.command().create().
2. Added a note on vBuilder and fixed vBuilder() vs newBuilder() naming.
3. Added Validation User Guide to source control and created a link to this guide from Java Quick Start Guide and spine.io/about page, Built-in Validation feature description. 