### PR TITLE
Modifying Concepts section navigation and header's name to fix #132

### DIFF
--- a/_includes/doc-side-concepts-nav.html
+++ b/_includes/doc-side-concepts-nav.html
@@ -3,6 +3,16 @@
     <li><h5 class="doc-side-nav-title">Concepts</h5></li>
     <li>
         <ul id="doc-side-nav-inside">
+            <li><h6 class="doc-side-nav-sub-title">Messaging</h6></li>
+            <li><a href="{{ site.baseurl }}/docs/concepts/command.html" {% if current[3] == 'command.html' %}class='current'{% endif %}>Command</a></li>
+            <li><a href="{{ site.baseurl }}/docs/concepts/event.html" {% if current[3] == 'event.html' %}class='current'{% endif %}>Event</a></li>
+            <li><a href="{{ site.baseurl }}/docs/concepts/rejection.html" {% if current[3] == 'rejection.html' %}class='current'{% endif %}>Rejection</a></li>
+            <li><a href="{{ site.baseurl }}/docs/concepts/command-handler.html" {% if current[3] == 'command-handler.html' %}class='current'{% endif %}>Command Handler</a></li>
+            <li><a href="{{ site.baseurl }}/docs/concepts/event-subsriber.html" {% if current[3] == 'event-subsriber.html' %}class='current'{% endif %}>Event Subscriber</a></li>
+        </ul>
+    </li>
+    <li>
+        <ul id="doc-side-nav-inside">
             <li><h6 class="doc-side-nav-sub-title">Entities</h6></li>
             <li><a href="{{ site.baseurl }}/docs/concepts/identifier.html" {% if current[3] == 'identifier.html' %}class='current'{% endif %}>Identifier</a></li>
             <li><a href="{{ site.baseurl }}/docs/concepts/aggregate.html" {% if current[3] == 'aggregate.html' %}class='current'{% endif %}>Aggregate</a></li>
@@ -10,16 +20,6 @@
             <li><a href="{{ site.baseurl }}/docs/concepts/projection.html" {% if current[3] == 'projection.html' %}class='current'{% endif %}>Projection</a></li>
             <li><a href="{{ site.baseurl }}/docs/concepts/repository.html" {% if current[3] == 'repository.html' %}class='current'{% endif %}>Repository</a></li>
             <li><a href="{{ site.baseurl }}/docs/concepts/snapshot.html" {% if current[3] == 'snapshot.html' %}class='current'{% endif %}>Snapshot</a></li>
-        </ul>
-    </li>
-    <li>
-        <ul id="doc-side-nav-inside">
-            <li><h6 class="doc-side-nav-sub-title">Messages</h6></li>
-            <li><a href="{{ site.baseurl }}/docs/concepts/command.html" {% if current[3] == 'command.html' %}class='current'{% endif %}>Command</a></li>
-            <li><a href="{{ site.baseurl }}/docs/concepts/event.html" {% if current[3] == 'event.html' %}class='current'{% endif %}>Event</a></li>
-            <li><a href="{{ site.baseurl }}/docs/concepts/rejection.html" {% if current[3] == 'rejection.html' %}class='current'{% endif %}>Rejection</a></li>
-            <li><a href="{{ site.baseurl }}/docs/concepts/command-handler.html" {% if current[3] == 'command-handler.html' %}class='current'{% endif %}>Command Handler</a></li>
-            <li><a href="{{ site.baseurl }}/docs/concepts/event-subsriber.html" {% if current[3] == 'event-subsriber.html' %}class='current'{% endif %}>Event Subscriber</a></li>
         </ul>
     </li>
     <li>


### PR DESCRIPTION
This is the fix for #132 
In Concepts navigation: 
- Changed "Messages" header name into "Messaging",
- Swapped"Messaging" and "Entities" sections.