### PR TITLE
Changes addressing issue #82: "Defining Aggregate guide"

### DIFF
--- a/_includes/doc-side-guides-nav.html
+++ b/_includes/doc-side-guides-nav.html
@@ -7,6 +7,7 @@
     <li><a href="{{ site.baseurl }}/docs/guides/model-definition.html" {% if current[3] == 'model-definition.html' %}class='current'{% endif %}>Model Definition</a></li>
     <li><a href="{{ site.baseurl }}/docs/guides/validation-user-guide.html" {% if current[3] == 'validation-user-guide.html' %}class='current'{% endif %}>Validation User Guide</a></li>
     <li><a href="{{ site.baseurl }}/docs/guides/creating-rejection-messages.html" {% if current[3] == 'creating-rejection-messages.html' %}class='current'{% endif %}>Defining Rejections</a></li>
+    <li><a href="{{ site.baseurl }}/docs/guides/defining-aggregate.html" {% if current[3] == 'defining-aggregate.html' %}class='current'{% endif %}>Defining Aggregate</a></li>
     <li><h6 class="doc-side-nav-title">Related Guides</h6></li>
     <li><a href="https://developers.google.com/protocol-buffers/docs/overview" target="_blank">Protocol Buffers</a></li>
     <li><a href="https://grpc.io/docs/guides/index.html" target="_blank">gRPC</a></li>

--- a/docs/guides/defining-aggregate.md
+++ b/docs/guides/defining-aggregate.md
@@ -1,0 +1,10 @@
+---
+title: Defining Aggregate 
+headline: Defining Aggregate
+bodyclass: docs
+layout: docs
+sidenav: doc-side-guides-nav.html
+type: markdown
+---
+<p class="coming-soon">Coming soon...</p>
+<hr>

--- a/docs/guides/naming-conventions.md
+++ b/docs/guides/naming-conventions.md
@@ -133,6 +133,8 @@ because:
     a generated data type for holding the state of the entity.
  2. Such a data structure does not represent a whole `Aggregate` or `ProcessManager` thing anyway. 
     It's just data.
+
+<p class="note">For details on aggregates usage, refer to a [Defining Aggregate Guide](/docs/guides/defining-aggregate.html).</p>  
  
 ## Packages
 
@@ -220,6 +222,8 @@ These classes are used in the `throws` clause of command handling methods.
 
 The arrangement with message classes nested under `Rejections` class, and top-level `Throwable`s
 is required to avoid name clashes while keeping these generated classes under the same package.
+
+<p class="note">For details on rejections usage, refer to [Defining Rejections Guide](/docs/guides/creating-rejection-messages.html).</p>
 
 #### Server-side code
 


### PR DESCRIPTION
Changes addressing issue #82: 
1.) Created defining-aggregate.md page with Coming soon content;
2.) Added a page to Guides navigation section;
3.) In naming-conventions.md added a link to Defining Aggregates guide from “Entity States” section of the “Naming Conventions” document;
4). In naming-conventions.md added a link to Defining Rejections user guide (was a TODO item in this document).