### PR TITLE
Changes addressing issue #117 "Create Roadmap page" 

### DIFF
--- a/faq/index.html
+++ b/faq/index.html
@@ -72,6 +72,28 @@ headline: 'Frequently Asked Questions'
                         <p>The framework is based on and supports only <a href="https://developers.google.com/protocol-buffers/docs/proto3" target="_blank">proto3 dialect</a>.</p>
                     </div>
                 </li>
+
+                <li class="faq-item">
+                    <h6 class="faq-headline">
+                        <span class="panel-title collapsed" data-toggle="collapse" data-target="#what-is-the-product-roadmap" aria-expanded="false" aria-controls="what-is-the-product-roadmap">What is the product Roadmap?</span>
+                        <a class="anchor-link" href="#which-version-of-protobuf-can-use"><i class="far fa-link"></i></a>
+                    </h6>
+                    <div class="faq-content collapse" id="what-is-the-product-roadmap">
+                        <p>Here are our plans for the future versions of Spine:</p>
+                        <ul>
+                            <li><b>Release version 1.0;</b></li>
+                            <li><b>Implement Catch-Up for Projections in Java;</b></li>
+                        </ul>
+                        <p>We shall also concentrate on coverage of popular programming languages and technologies:</p>
+                        <ul>
+                            <li><b>Node.js</b> to enable <a href="/docs/concepts/projection.html" >Projections </a> development by our users creating UI.</li>
+                            <li><b>Kotlin</b> client library.</li>
+                            <li><b>Swift</b> client library.</li>
+                        </ul>
+                </li>
+                    </div>
+                </li>
+
             </ul>
         </div>
     </div>


### PR DESCRIPTION
Changes addressing issue #117: 
In FAQ > in index.html file added an entry describing our future plans.

Note: Roadmap placement can be discussed. We can add a Roadmap page in the top-right navigation bar on spine.io website.