### PR TITLE
Add a stub page for Acknowledgement

### DIFF
--- a/docs/concepts/acknowledgement.md
+++ b/docs/concepts/acknowledgement.md
@@ -1,0 +1,15 @@
+---
+title: Acknowledgement
+headline: Concepts
+bodyclass: docs
+layout: docs
+sidenav: doc-side-concepts-nav.html
+type: markdown
+---
+<h2 class="top">Acknowledgement</h2> 
+
+Acknowledgement is an outcome of sending a Command to the Command Service.
+
+It tells whether the Command has been accepted for handling. 
+
+

--- a/docs/concepts/diagrams/spine-architecture-diagram.svg
+++ b/docs/concepts/diagrams/spine-architecture-diagram.svg
@@ -145,34 +145,7 @@
             </g>
         </g>
 
-        <g class="g-caption event-store" pointer-events="all">
-            <path class="event-store path"
-                  d="M 1036 578 C 1036 551.33 1146 551.33 1146 578 L 1146 638 C 1146 664.67 1036 664.67 1036 638 Z"
-                  fill="#ffb366" stroke="#ffffff" stroke-width="2" stroke-miterlimit="10"
-                  pointer-events="all"/>
-            <path class="event-store path" d="M 1036 578 C 1036 598 1146 598 1146 578" fill="none"
-                  stroke="#ffffff"
-                  stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
-            <g transform="translate(1066.5,601.5)">
-                <switch>
-                    <foreignObject style="overflow:visible;" pointer-events="all" width="45"
-                                   height="36"
-                                   requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" class="box-caption event-store"
-                             style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; vertical-align: top; width: 47px; white-space: nowrap; overflow-wrap: normal; text-align: center;">
-                            <div xmlns="http://www.w3.org/1999/xhtml"
-                                 style="display:inline-block;text-align:inherit;text-decoration:inherit;">
-                                Event<br/>Store
-                                <br/>
-                            </div>
-                        </div>
-                    </foreignObject>
-                    <text x="23" y="26" fill="#1B96DE" text-anchor="middle" font-size="16px"
-                          font-family="Helvetica">[Not supported by viewer]
-                    </text>
-                </switch>
-            </g>
-        </g>
+
         <rect class="ui rect end-user" x="121" y="92" width="56" height="1010" rx="3.36" ry="3.36" fill="#cda2be"
               stroke="none" pointer-events="none"/>
         <g transform="translate(69.5,582.5)rotate(-90,79,14)">
@@ -536,30 +509,6 @@
         <path class="arrow stand-query-service" d="M 343.47 766 L 353.47 762.67 L 353.47 769.33 Z" fill="#82b366" stroke="#82b366"
               stroke-width="4" stroke-miterlimit="10" pointer-events="none"/>
 
-        <g class="g-caption event-bus" pointer-events="all">
-            <rect class="rect event-bus" x="758" y="421.5" width="53" height="373" rx="3.18"
-                  ry="3.18" fill="#ffb366"
-                  stroke="none" transform="rotate(90,784.5,608)" pointer-events="all"/>
-            <g transform="translate(727.5,593.5)">
-                <switch>
-                    <foreignObject style="overflow:visible;" pointer-events="all" width="113"
-                                   height="28"
-                                   requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" class="box-caption event-bus"
-                             style="display: inline-block; font-size: 25px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; vertical-align: top; width: 115px; white-space: nowrap; overflow-wrap: normal; text-align: center;">
-                            <div xmlns="http://www.w3.org/1999/xhtml"
-                                 style="display:inline-block;text-align:inherit;text-decoration:inherit;">
-                                Event Bus
-                                <br/>
-                            </div>
-                        </div>
-                    </foreignObject>
-                    <text x="57" y="27" fill="#FFFFFF" text-anchor="middle" font-size="25px"
-                          font-family="Helvetica">Event Bus&lt;br&gt;
-                    </text>
-                </switch>
-            </g>
-        </g>
         <path class="arrow event-bus-event-store" d="M 972.67 608.67 L 1021.53 608.67" fill="none" stroke="#ff8000" stroke-width="4"
               stroke-miterlimit="10" pointer-events="none"/>
         <path class="arrow event-bus-event-store" d="M 1031.53 608.67 L 1021.53 612 L 1021.53 605.33 Z" fill="#ff8000" stroke="#ff8000"
@@ -851,6 +800,60 @@
                         </div>
                     </foreignObject>
                     <text x="34" y="22" fill="#009900" text-anchor="middle" font-size="14px"
+                          font-family="Helvetica">[Not supported by viewer]
+                    </text>
+                </switch>
+            </g>
+        </g>
+
+        <g class="g-caption event-bus" pointer-events="all">
+            <rect class="rect event-bus" x="758" y="421.5" width="53" height="373" rx="3.18"
+                  ry="3.18" fill="#ffb366"
+                  stroke="none" transform="rotate(90,784.5,608)" pointer-events="all"/>
+            <g transform="translate(727.5,593.5)">
+                <switch>
+                    <foreignObject style="overflow:visible;" pointer-events="all" width="113"
+                                   height="28"
+                                   requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" class="box-caption event-bus"
+                             style="display: inline-block; font-size: 25px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; vertical-align: top; width: 115px; white-space: nowrap; overflow-wrap: normal; text-align: center;">
+                            <div xmlns="http://www.w3.org/1999/xhtml"
+                                 style="display:inline-block;text-align:inherit;text-decoration:inherit;">
+                                Event Bus
+                                <br/>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="57" y="27" fill="#FFFFFF" text-anchor="middle" font-size="25px"
+                          font-family="Helvetica">Event Bus&lt;br&gt;
+                    </text>
+                </switch>
+            </g>
+        </g>
+
+        <g class="g-caption event-store" pointer-events="all">
+            <path class="event-store path"
+                  d="M 1036 578 C 1036 551.33 1146 551.33 1146 578 L 1146 638 C 1146 664.67 1036 664.67 1036 638 Z"
+                  fill="#ffb366" stroke="#ffffff" stroke-width="2" stroke-miterlimit="10"
+                  pointer-events="all"/>
+            <path class="event-store path" d="M 1036 578 C 1036 598 1146 598 1146 578" fill="none"
+                  stroke="#ffffff"
+                  stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
+            <g transform="translate(1066.5,601.5)">
+                <switch>
+                    <foreignObject style="overflow:visible;" pointer-events="all" width="45"
+                                   height="36"
+                                   requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" class="box-caption event-store"
+                             style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; vertical-align: top; width: 47px; white-space: nowrap; overflow-wrap: normal; text-align: center;">
+                            <div xmlns="http://www.w3.org/1999/xhtml"
+                                 style="display:inline-block;text-align:inherit;text-decoration:inherit;">
+                                Event<br/>Store
+                                <br/>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="23" y="26" fill="#1B96DE" text-anchor="middle" font-size="16px"
                           font-family="Helvetica">[Not supported by viewer]
                     </text>
                 </switch>

--- a/docs/concepts/diagrams/spine-architecture-diagram.svg
+++ b/docs/concepts/diagrams/spine-architecture-diagram.svg
@@ -158,10 +158,9 @@
                     <foreignObject style="overflow:visible;" pointer-events="all" width="45"
                                    height="36"
                                    requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml"
+                        <div xmlns="http://www.w3.org/1999/xhtml" class="box-caption event-store"
                              style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; vertical-align: top; width: 47px; white-space: nowrap; overflow-wrap: normal; text-align: center;">
                             <div xmlns="http://www.w3.org/1999/xhtml"
-                                 class="box-caption event-store"
                                  style="display:inline-block;text-align:inherit;text-decoration:inherit;">
                                 Event<br/>Store
                                 <br/>


### PR DESCRIPTION
This PR adds a stub page for Acknowledgement — in order to provide a navigation destination for a corresponding arrow at the Architecture diagram.

Also, an order of SVG elements was updated to make the "Event Store" element properly clickable.