### PR TITLE
Architecture diagram cleanup

### DIFF
--- a/docs/concepts/diagrams/spine-architecture-diagram.svg
+++ b/docs/concepts/diagrams/spine-architecture-diagram.svg
@@ -1,5 +1,5 @@
-<svg id="spine-diagram" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="-0.5 -0.5 1410 1119"
-     content="&lt;mxfile modified=&quot;2019-04-10T17:03:06.581Z&quot; host=&quot;www.draw.io&quot; agent=&quot;Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.86 Safari/537.36&quot; version=&quot;10.6.0&quot; etag=&quot;ODAWjiJNR9-UxIueV4r_&quot; type=&quot;google&quot;&gt;&lt;diagram id=&quot;oV3KBuGMJAs_fP7ZHJGM&quot;&gt;7V1bc5tIFv41egzV98tjbCc7W7VTNbvey8wjlrDNRhZahBN7fv12I0D0BYREI8mO5XJiNahBfb5z+tyZ4eunl7/k8frx12yRLGcILF5m+GaGEIcQqP/0yOt2hFJUjTzk6WI7BncDt+mfSTVYn/acLpKNcWKRZcsiXZuD82y1SuaFMRbnefbDPO0+W5pXXccPiTNwO4+X7uh/0kXxWI1iCnYHfknSh8f60ghUR+7i+beHPHteVRdcZatke+QpruepTt08xovsR2sIf5nh6zzLiu1fTy/XyVIvbL1k28997Tja3HOerIohH0DbD3yPl8/V167uq3it16H8Iok+H8zw1Y/HtEhu1/FcH/2hSK/GHounpXoH1Z+ZOpIWmuRCn70p8uxbcp0ts1wNleuAr6pLJnmRvHTeNmwWQyEsyZ6SIn9Vp1Qf+IQ4YtsPVfD6hCmp1vRHi1oEiO3gY5tSENIKJxVGHpor7NZK/VEtl3/p8P6l0yBYd37dCrjxXX06OGIZam5pLQNylwEz7FsGgMcvA9m/DHswY4JkhvD1V/2jjtyny2Vr/Gv5UuMPebxI1RpZwLrPdkPqdAH0TzVeyRfI9AVrpgND0Yh7yUA5iRjAsv4VBkmwlBHiklPEAeESEubSR/CIK6HZ/HqoJWgEsGBqds4wVbOOJx31kI4t1fWuFul3PfcyfViVB9j/nrVEulom98Xunfrrofq//NRdbo+oOyinqkfHiJZumGyP1EIaeYBTnloh4Wv8lC41bX5Jlt+TIp3HJkTUyjpQYuVLjddLMlfQSNTBKw0cNcXyc3WgyNb1dNX3LO9di8XVwz/1wRvENYSX8WZTffE4n9fwDANIUjPha83p2MGcEMgFmZRgPKzYB6zeKayAKdkggCeEFQ8MK7V4q3rsqkIMAtdqiZOXooW09nmXD8l6ixwCScTCQhLYkAS9iKxO1e9QGIBiSQyASlcVEsKzt6o9dTw+hYPP6+zpKV5pVF09b3zQsUDiUrcNisd4rc97ennQBld0v8x+zB/jvIjWeTZP9Bp7cbVexunq0115UzZasNJN+hSqxyxP/1QEjpcVAS2wGGirQUW79P5uSC7T9b/DqWOEmCiARDowoB4UEBRAHZYOCr58V/e9cYhdShmDwm01lfgWWwAAPCyP9E83EXcmGfCxdYAFl4hGXHCIql9z+bX+CwiQVCAmJFYGikMNLiIEuWh+PVsIYpFEQgLEEKfKfqs5fQytatvJs6XotTfoVe8i+sCnTUmlz+oEyNYv212g2WWUXVfTZjdYs4qzG5XomGnTzxYPt0WWJ70bzvYmu4RJJS/mr8tUbT35/m3H2UqucLkTDLO24JVkN198u5dPSmztMEN9Ed79rbVJhAErBMg0mSkVrkFWQ8Owl0EALQZCB3P/2ijqIPBXzZD3mjgXuFNc33xGV1/OvlMEoT/dpyNQ5iM+DEF91992vUy3EuDzer1U37JIs9UQZcHdP/JEyaXKm6RJsM5SvfGos+nVjN5o4f9cZJudAlbvBaWe3KXgGUwKLXcKRi6prz7rn90n/1bOfgPpSPoZ/iwPe6IQ9HGdetfL7HlhkuddUCcAK3Ho2n9QekiDQ5BmgKMxWS0+a8+/ene3zObf/vmYrvaYVgAwdn3tbD3EFYGS3wDO+/fDHvWt8Uaqm/yaLusbUvPkr7+rN59ABACpR/7QKImQMlaqgZuXCjfbd6/td78learWU+/xLR06WTjxDYuwCBRx/pBUQxT1EpsKHHGKSPNrSFFCYKT2R8Iw44JC5nFyDlDyOIgEoxRjRRcktfbRCZvqPn/TXNS6ydotWuueBJpTbLLnfJ5Un0KtuIg9ETddHYRZ/tbtyjkTKfjFr63TKi7vvmFiKiOEM4sptjPuWKShzDCu8fl4L5VrsMs1zcdNrpk/599Lb8r27pRu4/sG5YHWp4byRbdliWUkKSD1LzdVCUFJpKwfwIhUNqdERxk6o3kAIgZNDceSvkN5QO2ylr8Po0mYQBmN5h1TsOfGKBh1Pqz0sGBc5rq8tTavIN+lLrD4SW/fq7vNujYCj1P69uw6DaNenNNAwRSbRHS9NI3FZWjiAXx1sNuZPNjyJ8ryd8z5zw8PefIQF4lN4k6zveXCNofG3chtoW5is+eqe5zWLtr81loLWtXQXufxU7pY6Mt4DdGds3wQwqUELc/zbGsPh0AotDwFuJZ/LYiSqSwR151sBi4GAEP4gLFzSt8m+fd0525wQh2n8Dl0OaT3+RPuy9dof0Lb89wJ0QBQUru6uQENdEnDEIEz6PqkQ4gdL7r+/pyU39vF1hHy5+Rern3K6tuMh9jgY/iE4EPdPvbg4Lt9vtvM83S9Vbo+MHjBGBQcRZAzwgEVAmHqOpKmQyR0iKxNwjqInW7KKdP5l93glRm+n2dP6bz6u4WG5CUttCcHRLR698es5aVpHWo8PDMrGa3DFDeN3/8mRfFaUVb7DLW6nheP2UO2ipd/y7auQIfgboimJ42AsSvkhGz6lK/ZYJfT1vo01fC2G2o75gIpT5bKmvpuzj8KB64v3gXGlK4ReBfDBO1f5C7PYQM3KVAbcBGs8XesY7Cbja0EC+RJLKMejZj28G2HzU5lJCiHBG3/Zcy6sGUFDnVqICb6J+rwaRzhFRiSIXwEwASq4rLn8lh34o4RPB3wTGcBBx4dJgzwGIgQYEIySiFHBJp44VC7wQWrTiHyWBhKe9rJYDhN4OTcMKwWqAbabWP9l5vqlgz+gwHAaGKCMdcvEAaMttrEbXfwYF+u5RN2JgqIt2lCDufGW3ARJrGbdxJKhFkBgLokZKyUciYKFABA2H+dUP55b0p6NyTnOmU1nR8PSo9GfWlCcBFvHhsXawBsmwQUwmPQTSIRndTdYyWiM1FAiehGGyov7JC00BMkjnwi+xHY2DWLNE/mpYsF3/xINkVpHhdxNQJsFwWsnAm/tP4O6FiAtme1tlBayPOlpITw0XtSvo8K3pj5oztHatoTwNkLm58rVFNn8dUaWU3yE0RqPCnfNdXWo2J6Plj8I9k8L4sBcb31B1SGQYUT14UxFVRwtzN8HFS6XOF3A7zfH0jpRIqlakDX5zAZUtw08TDA+Nd60ZsY8AGBPmEh2QmFBXIgcFuUkfvLKw94n0Eru5BsaOA0SCEZfp/e49lYU5NQFplpl5xP5X7DyPI6h3H+EoIOmTacIYrfpys4AKasmiAsa4xNjilJcETD4EgSZE8VEDtvKZP8pNixAooEnAw7R0dBbeRMGAXFh/le34rMOWP4iVixcMbgZIhztqpjA1DOVjpdAAq77ta6yvpC+zDsK7V2HaqTq89tL6+isV6JIK2yhIknKnzYxb4GWDSEUu3z2I4XRk1rhrOnZDiZZ+rvXemgfmNUDv7efvPHzEhQ66o4HJHeYWZ/YV/2F+iFj8CipwiRcxmxVhGiC6xT1F8pDT7SeSOYSwwBdmxIGO0OiTqEcHD0CjDru4Nh8rQ7NDtG4vpc4O+JraQkbcaKRNlsq4e5PEzSlwTax3Cj9QUKeYQ6mUYoe/r8TMOsu2K1qXooY9gTNe798HoG8XnzLdSfpO+XB+Sezl6NkuAJ/Y/b0+3qSur6Y7BPHYUsgJuU+Dzlb98uHbM9/96SX1UjAQYPllfj5Y6SLN2bNaT4EjoGEGneFrLlxeCOAQJEdbKy/pf1TxtQDCGHAZoav32Fx509pmyLaGwzqX2d5rpk1bHNpLhXaAYQdpwJy/0MJfWYMBB4mgjJAKXLxI0L7Eo6b1K1DMX8UTeU2kvUg3YjT6BvBFl7OzJPQjfNnibdEGA+uvnCeTxAu3Ayje/97PuUd7+pzdCwpufoHYlD0KMJq+OGJnymHYmjgzaSofuTFlzj96dJzEfS3Yj8oD6MbhbM66ZInmZOV9/DuymePw/CEzWX5csjTh1/YQAByhiyNz6GfQIUeja+EA3AyDSBhLML0JGKvpZoLdnbr+ePlqAQENojQiGGlyBCGVQ32a4eNGWd9jnvjglypKvB7hGGBYpa01LLtReoVoJBkwtxtYKdd2m3RDv0/KphdqhaDOJrvfPhNUFCuOVAfq9JXxRvsDB1AyGt1kXg11RJ0RPZEEPE6qXYEHaaiJtljoSHZCKE/dCdZv6hJF2OkmQnpwlPPcpkKhId4JEO/jCmLjXnHPxpNe2kntByncRtNXcOsPgDHNEX/SSsiWhCLJp4A/7TUcX1jv5cLGG7vQjhpyXAgDzmd00AS5325JBPuPhv/el8J9HjMHbN1AlpMiCR9l0zBLQWH51y8Qc4kd7z4ktoF0+cej8eYP7/jBLJzlo58SY9IC/yPbOFsH3bvqrgCZd/mvy5c+fIG435zaYqwVvzM2wruo1fN3xSvJUzwu2HkR2QM9I/UbgsETbANfC+IdYVaOHDIy1SspmZVlW/P2FaFcPcFVbTFYBIFgkgqaZA+a+tPhxZD2IHTyiUvpDNxI9bqW+/8y6t82m1BYQKhrBpkhffEldWzFU+/sioXogwPDxpsWFyqKYTJqNrd+CET1PqjplCbnMsBNSXNBaGZfWTmghnUILqX+PSUtdPt6Ofx/Gv2gN7QqxioifF2PwoK3NiKP/W9xWMf9Ep+deOYE6fk6C5CJtcRCk5hosMkVDdXFsWGLnLNe/uOhoj0SsKjOBsuAqlurdYu0JpGzntZnZK+qotmNqqz19tASHU4nb3svxh4tguo5Bqsb2tbNIdDcx5GbLioKGeH2U3gcPVhbvv0+4iyA05Ml4uHNa846Ph5KF7KrMeMi3EdFX3Ttj/2JaTFID+iQKae4dlG/90AGzvcBCZOxwTzcBJ9URSVz03mJ6yrp+EwbTag6K6U7ouaz0ZwAPkDH88we2dt2+TyJLcxOWnqdq3sQGRpqas6jlfvl7l8fyb1jL3JTyaizs0/RG7Evr6+gvdFx/pSY3cXWh7jrawWzolKouwPN2C1658xjgMwaHdsxHWq96mOHUpTngIkg+Ibb1tkl+VP5dNcgYHkjxEHi0b3wJafdmXma/X739yhQl14sKo0Bwx4ZvO49yFE1s9bvR5Tm/JMKCy0nYA8uhidbjGCAiGeDYV8wUEj4CVp390vDgWUh94CocnLtz48mRo4m7sr53sHzrNf0/sv0zGHpGRoTXI6VMCOKcRFgzWv5aHjPryM2rrp01AFoJ+bpTog3576Qd76eeLmE5GPzdK8Ibpd5qUHG71t8KeJyZPRq9pWi+fvdK0yWPQ/fXa4RUCz5DHwEVfexgs2SVUknJgerQwV7fVetkdPYZX41sCiU9TLcqtKkMcONDBXT9zW7T9I1lnm7TIKv67eKWwU+AFkGgMW4nP3FUBkcdODeGM4gNyzt9ig75WSz1pxanJbmDCODUyU1YEkKcXpBBj2BdypvwCQs6C8bbgNG+RKOta4N3ryH7oEtq9maj6au5VA8vY5rkwzbcJWzHPp2l8cXbmbWV+MWmwEaD96R4+NhrEuE3Uz5IV4kyZYZiSHh2IIXQBnCsxjlq8abWH0A2cQ7CuFRrHgkawR88KxboY25cNy7oDIgJvmHXfhCVB4EX0pHEsCQmnsSRqq3hqS6J6NFYwVunvSDKBk0T3hfjqcZJcq9fYsrFLcFIS7o1ZTOU0cUMWH/Qb5aQku1ajJ6CfcIMEv1UPtEDg13gVP4RvKjoxEc/jqSQePW0yor3T5tfn6W2nNYVuO1qiS+hXzaXwNZmrtXFsbf7DyzmsidhEWoQVB62v09nOH4K+80drHfXjaPqlnuHH3CsCf0bPpt1kpk78PIFvU3xEa85uY1EgLtHGIkJMYmMRaeF2IhuLiLDlpsKN1oRglQ93xCGsgi6hAszmFArwJJxCgeUQnIhTaFXlGoxT3mnArOEUPhuqVx/rbB/NRxApvaLHO34RD67STwILooE7E4mxe8yI6hrxPkNOhwR3dVgKGZsJknsea9H/0DeBSD1QMl0EYBOGOm3UCZFevmIXwVfE2khqS+1gvrInstP+T8pX08SDhtsq8C6GCQqwf0hhMgekHRwwGq5NXnRFQMR8ubdhyiKRVRfepN4eXAlfd4bomihcJaTwBE7m3zYOrly3RJ5s0j/ju/IETaoK4upsejWjN9oh8VxkVakPbPknlsl94fFOFPrZW+aDuD6R/Vhr0OspHMqzIq5GnNz8srRwma5/af39bwN143L2LVdV0zN/D+qC+DSmaQh3bp/GaFlALH+nkg0nK5E+WhZgtGeicLJAnrzSY9fNcdRTHc4ahJM9QTjOfE+JmyqeI09e6fEe6NcXBOfeh1RNRj/kkdtG3d68WbNdNR2+L19ugd1vefbfakccWGp3SeQ/Ufi1N4bOqTwl+acJRZzbbG75V61ETX4O/yoEvM/BygE3ArWX4WA9ukcs57B/olPar/W1zXBpI6M+4qS9wLUrQLhww2SBoqTqbZ7pvWRHaPXlH3/NFok+4/8=&lt;/diagram&gt;&lt;/mxfile&gt;"
+<svg id="spine-diagram" xmlns="http://www.w3.org/2000/svg" version="1.1"
+     viewBox="-0.5 -0.5 1410 1119"
      style="background-color: rgb(255, 255, 255);">
 
     <!--
@@ -84,7 +84,8 @@
      -->
     <defs/>
     <g class="diagram-content">
-        <rect class="outer-frame end-user" x="0" y="2" width="1408" height="1115" fill-opacity="0.8" fill="#ffffff" stroke="none"
+        <rect class="outer-frame end-user" x="0" y="2" width="1408" height="1115" fill-opacity="0.8"
+              fill="#ffffff" stroke="none"
               pointer-events="none"/>
         <g class="g-caption bounded-context" pointer-events="all">
             <rect class="bounded-context rect layer-3 end-user" x="438" y="113" width="882"
@@ -97,7 +98,8 @@
                   height="987" fill="#ffffff" stroke="#cfcfcf"
                   stroke-width="2" pointer-events="none"/>
             <g transform="translate(749.5,106)">
-                <text x="100" y="28" fill="#666666" text-anchor="middle" font-size="26px" pointer-events="all"
+                <text x="100" y="28" fill="#666666" text-anchor="middle" font-size="26px"
+                      pointer-events="all"
                       font-family="Helvetica" class="box-caption bounded-context end-user">
                     Bounded Context
                 </text>
@@ -109,7 +111,8 @@
                   ry="3.18" fill="#3399ff"
                   stroke="none" pointer-events="all"/>
             <g transform="translate(403.5,346.5)rotate(-90,82.5,14)">
-                <text x="83" y="25" fill="#FFFFFF" text-anchor="middle" font-size="25px" pointer-events="all"
+                <text x="83" y="25" fill="#FFFFFF" text-anchor="middle" font-size="25px"
+                      pointer-events="all"
                       font-family="Helvetica" class="box-caption command-bus">
                     Command Bus
                 </text>
@@ -117,31 +120,38 @@
         </g>
 
 
-        <rect class="ui rect end-user" x="121" y="92" width="56" height="1010" rx="3.36" ry="3.36" fill="#cda2be"
+        <rect class="ui rect end-user" x="121" y="92" width="56" height="1010" rx="3.36" ry="3.36"
+              fill="#cda2be"
               stroke="none" pointer-events="none"/>
         <g transform="translate(69.5,582.5)rotate(-90,79,14)">
-            <text x="79" y="27" fill="#FFFFFF" text-anchor="middle" font-size="25px" pointer-events="all"
+            <text x="79" y="27" fill="#FFFFFF" text-anchor="middle" font-size="25px"
+                  pointer-events="all"
                   font-family="Helvetica" class="box-caption ui end-user">
                 User Interface
             </text>
         </g>
         <g transform="translate(32.5,16.5)">
-            <text x="132" y="34" fill="#BABABA" text-anchor="middle" font-size="32px" pointer-events="all"
+            <text x="132" y="34" fill="#BABABA" text-anchor="middle" font-size="32px"
+                  pointer-events="all"
                   font-family="Helvetica" class="title-caption">
                 Client Applications
             </text>
         </g>
         <g transform="translate(728.5,16.5)">
-            <text x="125" y="34" fill="#BABABA" text-anchor="middle" font-size="32px" pointer-events="all"
+            <text x="125" y="34" fill="#BABABA" text-anchor="middle" font-size="32px"
+                  pointer-events="all"
                   font-family="Helvetica" class="title-caption">
                 Cloud Application
             </text>
         </g>
-        <path class="arrow command-dispatcher-pm-repo" d="M 555 375 L 555.93 466 Q 556 476 566 475.83 L 581.53 475.57" fill="none"
+        <path class="arrow command-dispatcher-pm-repo"
+              d="M 555 375 L 555.93 466 Q 556 476 566 475.83 L 581.53 475.57" fill="none"
               stroke="#0066cc" stroke-width="4" stroke-miterlimit="10" pointer-events="none"/>
-        <path class="arrow command-dispatcher-pm-repo" d="M 591.53 475.41 L 581.59 478.91 L 581.47 472.24 Z" fill="#0066cc" stroke="#0066cc"
+        <path class="arrow command-dispatcher-pm-repo"
+              d="M 591.53 475.41 L 581.59 478.91 L 581.47 472.24 Z" fill="#0066cc" stroke="#0066cc"
               stroke-width="4" stroke-miterlimit="10" pointer-events="none"/>
-        <path class="arrow integration-events" d="M 1283.47 77.06 Q 1297 50 1331.5 50 Q 1366 50 1366 81 Q 1366 112 1337.07 125.78"
+        <path class="arrow integration-events"
+              d="M 1283.47 77.06 Q 1297 50 1331.5 50 Q 1366 50 1366 81 Q 1366 112 1337.07 125.78"
               fill="none" stroke="#0066cc" stroke-width="4" stroke-miterlimit="10"
               pointer-events="none"/>
 
@@ -152,10 +162,12 @@
             <path class="arrow integration-events"
                   d="M 1328.04 130.08 L 1335.63 122.77 L 1338.5 128.79 Z" fill="#0066cc"
                   stroke="#0066cc" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/>
-            <g transform="translate(1330,80)" requiredFeatures="http://www.w3.org/Graphics/SVG/feature/1.2/#TextFlow">
-                <text fill="#0066CC" text-anchor="middle" font-size="14px" font-family="Helvetica" pointer-events="all"
+            <g transform="translate(1330,80)"
+               requiredFeatures="http://www.w3.org/Graphics/SVG/feature/1.2/#TextFlow">
+                <text fill="#0066CC" text-anchor="middle" font-size="14px" font-family="Helvetica"
+                      pointer-events="all"
                       class="arrow-caption integration-events">
-                    <tspan x="0" >Integration</tspan>
+                    <tspan x="0">Integration</tspan>
                     <tspan x="0" dy="1.2em">Events</tspan>
                 </text>
             </g>
@@ -166,7 +178,8 @@
                   ry="3.18" fill="#3399ff"
                   stroke="none" pointer-events="all"/>
             <g transform="translate(238.5,229.5)rotate(-90,74,14)">
-                <text x="74" y="20" fill="#ffffff" text-anchor="middle" font-size="18px" pointer-events="all"
+                <text x="74" y="20" fill="#ffffff" text-anchor="middle" font-size="18px"
+                      pointer-events="all"
                       font-family="Helvetica" class="box-caption command-service">
                     Command Service
                 </text>
@@ -177,7 +190,8 @@
                   ry="3.18" fill="#97d077"
                   stroke="none" pointer-events="all"/>
             <g transform="translate(255.5,719.5)rotate(-90,57,14)">
-                <text x="57" y="20" fill="#FFFFFF" text-anchor="middle" font-size="18px" pointer-events="all"
+                <text x="57" y="20" fill="#FFFFFF" text-anchor="middle" font-size="18px"
+                      pointer-events="all"
                       font-family="Helvetica" class="box-caption query-service">
                     Query Service
                 </text>
@@ -188,7 +202,8 @@
                   rx="3.18" ry="3.18" fill="#97d077"
                   stroke="none" pointer-events="all"/>
             <g transform="translate(230.5,952.5)rotate(-90,82,14)">
-                <text x="82" y="20" fill="#FFFFFF" text-anchor="middle" font-size="18px" pointer-events="all"
+                <text x="82" y="20" fill="#FFFFFF" text-anchor="middle" font-size="18px"
+                      pointer-events="all"
                       font-family="Helvetica" class="box-caption subscription-service">
                     Subscription Service
                 </text>
@@ -203,7 +218,8 @@
                   d="M 279.53 217 L 269.53 220.33 L 269.53 213.67 Z" fill="#0066cc" stroke="#0066cc"
                   stroke-width="4" stroke-miterlimit="10" pointer-events="all"/>
             <g transform="translate(187.5,196.5)">
-                <text x="36" y="14" fill="#0066CC" text-anchor="middle" font-size="14px" pointer-events="all"
+                <text x="36" y="14" fill="#0066CC" text-anchor="middle" font-size="14px"
+                      pointer-events="all"
                       font-family="Helvetica" class="arrow-caption ui-command-service end-user">
                     Commands
                 </text>
@@ -219,7 +235,8 @@
                   stroke="#82b366"
                   stroke-width="4" stroke-miterlimit="10" pointer-events="all"/>
             <g transform="translate(202.5,692.5)">
-                <text x="25" y="14" fill="#009900" text-anchor="middle" font-size="14px" pointer-events="all"
+                <text x="25" y="14" fill="#009900" text-anchor="middle" font-size="14px"
+                      pointer-events="all"
                       font-family="Helvetica" class="arrow-caption ui-query-service end-user">
                     Queries
                 </text>
@@ -235,7 +252,8 @@
                   d="M 181.47 766 L 191.47 762.67 L 191.47 769.33 Z" fill="#82b366" stroke="#82b366"
                   stroke-width="4" stroke-miterlimit="10" pointer-events="all"/>
             <g transform="translate(204.5,742)">
-                <text x="23" y="16" fill="#009900" text-anchor="middle" font-size="14px" pointer-events="all"
+                <text x="23" y="16" fill="#009900" text-anchor="middle" font-size="14px"
+                      pointer-events="all"
                       font-family="Helvetica" class="arrow-caption query-service-ui end-user">
                     Results
                 </text>
@@ -251,8 +269,10 @@
                   d="M 280.53 942 L 270.53 945.33 L 270.53 938.67 Z" fill="#82b366" stroke="#82b366"
                   stroke-width="4" stroke-miterlimit="10" pointer-events="all"/>
             <g transform="translate(194.5,918)">
-                <text x="32" y="16" fill="#009900" text-anchor="middle" font-size="14px" pointer-events="all"
-                      font-family="Helvetica" class="arrow-caption ui-subscription-service end-user">
+                <text x="32" y="16" fill="#009900" text-anchor="middle" font-size="14px"
+                      pointer-events="all"
+                      font-family="Helvetica"
+                      class="arrow-caption ui-subscription-service end-user">
                     Subscribe
                 </text>
             </g>
@@ -266,8 +286,10 @@
                   d="M 179.24 987 L 187.24 984.33 L 185.24 987 L 187.24 989.67 Z" fill="#82b366"
                   stroke="#82b366" stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
             <g transform="translate(201.5,965.5)">
-                <text x="27" y="14" fill="#009900" text-anchor="middle" font-size="14px" pointer-events="all"
-                      font-family="Helvetica" class="arrow-caption subscription-service-ui end-user">
+                <text x="27" y="14" fill="#009900" text-anchor="middle" font-size="14px"
+                      pointer-events="all"
+                      font-family="Helvetica"
+                      class="arrow-caption subscription-service-ui end-user">
                     Updates
                 </text>
             </g>
@@ -278,48 +300,64 @@
                   fill="#97d077"
                   stroke="none" pointer-events="all"/>
             <g transform="translate(453.5,836.5)rotate(-90,32.5,14)">
-                <text x="33" y="25" fill="#FFFFFF" text-anchor="middle" font-size="25px" pointer-events="all"
+                <text x="33" y="25" fill="#FFFFFF" text-anchor="middle" font-size="25px"
+                      pointer-events="all"
                       font-family="Helvetica" class="box-caption stand">
                     Stand
                 </text>
             </g>
         </g>
-        <path class="arrow query-service-stand" d="M 339 713.76 L 443.53 713.76" fill="none" stroke="#82b366" stroke-width="4"
+        <path class="arrow query-service-stand" d="M 339 713.76 L 443.53 713.76" fill="none"
+              stroke="#82b366" stroke-width="4"
               stroke-miterlimit="10" pointer-events="none"/>
-        <path class="arrow query-service-stand" d="M 453.53 713.76 L 443.53 717.09 L 443.53 710.43 Z" fill="#82b366" stroke="#82b366"
+        <path class="arrow query-service-stand"
+              d="M 453.53 713.76 L 443.53 717.09 L 443.53 710.43 Z" fill="#82b366" stroke="#82b366"
               stroke-width="4" stroke-miterlimit="10" pointer-events="none"/>
 
-        <path class="arrow subscription-service-stand" d="M 339 943.5 L 443.53 942.62" fill="none" stroke="#82b366" stroke-width="4"
+        <path class="arrow subscription-service-stand" d="M 339 943.5 L 443.53 942.62" fill="none"
+              stroke="#82b366" stroke-width="4"
               stroke-miterlimit="10" pointer-events="none"/>
-        <path class="arrow subscription-service-stand" d="M 453.53 942.54 L 443.56 945.95 L 443.5 939.29 Z" fill="#82b366" stroke="#82b366"
+        <path class="arrow subscription-service-stand"
+              d="M 453.53 942.54 L 443.56 945.95 L 443.5 939.29 Z" fill="#82b366" stroke="#82b366"
               stroke-width="4" stroke-miterlimit="10" pointer-events="none"/>
 
-        <path class="arrow command-service-command-bus" d="M 339 217 L 443.53 217" fill="none" stroke="#0066cc" stroke-width="4"
+        <path class="arrow command-service-command-bus" d="M 339 217 L 443.53 217" fill="none"
+              stroke="#0066cc" stroke-width="4"
               stroke-miterlimit="10" pointer-events="none"/>
-        <path class="arrow command-service-command-bus" d="M 453.53 217 L 443.53 220.33 L 443.53 213.67 Z" fill="#0066cc" stroke="#0066cc"
+        <path class="arrow command-service-command-bus"
+              d="M 453.53 217 L 443.53 220.33 L 443.53 213.67 Z" fill="#0066cc" stroke="#0066cc"
               stroke-width="4" stroke-miterlimit="10" pointer-events="none"/>
 
-        <path class="arrow stand-query-service" d="M 458 766 L 353.47 766" fill="none" stroke="#82b366" stroke-width="4"
+        <path class="arrow stand-query-service" d="M 458 766 L 353.47 766" fill="none"
+              stroke="#82b366" stroke-width="4"
               stroke-miterlimit="10" pointer-events="none"/>
-        <path class="arrow stand-query-service" d="M 343.47 766 L 353.47 762.67 L 353.47 769.33 Z" fill="#82b366" stroke="#82b366"
+        <path class="arrow stand-query-service" d="M 343.47 766 L 353.47 762.67 L 353.47 769.33 Z"
+              fill="#82b366" stroke="#82b366"
               stroke-width="4" stroke-miterlimit="10" pointer-events="none"/>
 
-        <path class="arrow event-bus-event-store" d="M 972.67 608.67 L 1021.53 608.67" fill="none" stroke="#ff8000" stroke-width="4"
+        <path class="arrow event-bus-event-store" d="M 972.67 608.67 L 1021.53 608.67" fill="none"
+              stroke="#ff8000" stroke-width="4"
               stroke-miterlimit="10" pointer-events="none"/>
-        <path class="arrow event-bus-event-store" d="M 1031.53 608.67 L 1021.53 612 L 1021.53 605.33 Z" fill="#ff8000" stroke="#ff8000"
+        <path class="arrow event-bus-event-store"
+              d="M 1031.53 608.67 L 1021.53 612 L 1021.53 605.33 Z" fill="#ff8000" stroke="#ff8000"
               stroke-width="4" stroke-miterlimit="10" pointer-events="none"/>
 
-        <path class="arrow event-bus-projection-repo" d="M 663 634 L 663 728.53" fill="none" stroke="#ff8000" stroke-width="4"
+        <path class="arrow event-bus-projection-repo" d="M 663 634 L 663 728.53" fill="none"
+              stroke="#ff8000" stroke-width="4"
               stroke-miterlimit="10" pointer-events="none"/>
-        <path class="arrow event-bus-projection-repo" d="M 663 738.53 L 659.67 728.53 L 666.33 728.53 Z" fill="#ff8000" stroke="#ff8000"
+        <path class="arrow event-bus-projection-repo"
+              d="M 663 738.53 L 659.67 728.53 L 666.33 728.53 Z" fill="#ff8000" stroke="#ff8000"
               stroke-width="4" stroke-miterlimit="10" pointer-events="none"/>
 
-        <rect class="rect system-context-top border" x="566" y="152" width="350" height="160" fill="none" stroke="#cfcfcf" stroke-width="2"
+        <rect class="rect system-context-top border" x="566" y="152" width="350" height="160"
+              fill="none" stroke="#cfcfcf" stroke-width="2"
               stroke-dasharray="6 6" pointer-events="none"/>
 
-        <path class="arrow command-bus-command-dispatcher" d="M 513 243 L 581.96 243" fill="none" stroke="#0066cc" stroke-width="4"
+        <path class="arrow command-bus-command-dispatcher" d="M 513 243 L 581.96 243" fill="none"
+              stroke="#0066cc" stroke-width="4"
               stroke-miterlimit="10" pointer-events="none"/>
-        <path class="arrow command-bus-command-dispatcher" d="M 591.96 243 L 581.96 246.33 L 581.96 239.67 Z" fill="#0066cc" stroke="#0066cc"
+        <path class="arrow command-bus-command-dispatcher"
+              d="M 591.96 243 L 581.96 246.33 L 581.96 239.67 Z" fill="#0066cc" stroke="#0066cc"
               stroke-width="4" stroke-miterlimit="10" pointer-events="none"/>
 
         <g class="g-caption command-store" pointer-events="all">
@@ -332,40 +370,49 @@
                   stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
 
             <g transform="translate(839,255)">
-                <text x="0" y="0" fill="#FFFFFF" text-anchor="middle" font-size="16px" pointer-events="all"
+                <text x="0" y="0" fill="#FFFFFF" text-anchor="middle" font-size="16px"
+                      pointer-events="all"
                       font-family="Helvetica" class="box-caption command-store">
                     <tspan x="0">Command</tspan>
                     <tspan x="0" dy="1.2em">Store</tspan>
                 </text>
             </g>
         </g>
-        <rect class="rect command-dispatcher" x="596.5" y="206.5" width="140" height="75" fill="#3399ff" stroke="none"
+        <rect class="rect command-dispatcher" x="596.5" y="206.5" width="140" height="75"
+              fill="#3399ff" stroke="none"
               pointer-events="none"/>
         <g transform="translate(670,240)">
-            <text x="0" y="0" fill="#FFFFFF" text-anchor="middle" font-size="16px" pointer-events="all"
+            <text x="0" y="0" fill="#FFFFFF" text-anchor="middle" font-size="16px"
+                  pointer-events="all"
                   font-family="Helvetica" class="box-caption command-dispatcher">
                 <tspan x="2">Command</tspan>
                 <tspan x="0" dy="1.2em">Dispatcher</tspan>
             </text>
         </g>
-        <path class="arrow command-dispatcher-command-store" d="M 736.43 243 L 769.96 243" fill="none" stroke="#0066cc" stroke-width="4"
+        <path class="arrow command-dispatcher-command-store" d="M 736.43 243 L 769.96 243"
+              fill="none" stroke="#0066cc" stroke-width="4"
               stroke-miterlimit="10" pointer-events="none"/>
-        <path class="arrow command-dispatcher-command-store" d="M 779.96 243 L 769.96 246.33 L 769.96 239.67 Z" fill="#0066cc" stroke="#0066cc"
+        <path class="arrow command-dispatcher-command-store"
+              d="M 779.96 243 L 769.96 246.33 L 769.96 239.67 Z" fill="#0066cc" stroke="#0066cc"
               stroke-width="4" stroke-miterlimit="10" pointer-events="none"/>
 
         <g transform="translate(680.5,169.5)">
-            <text x="56" y="17" fill="#999999" text-anchor="middle" font-size="16px" pointer-events="all"
+            <text x="56" y="17" fill="#999999" text-anchor="middle" font-size="16px"
+                  pointer-events="all"
                   font-family="Helvetica" class="box-caption system-context-top">
                 System Context
             </text>
         </g>
-        <path class="arrow command-dispatcher-aggregate-repo" d="M 631.29 281.57 L 631.07 312 Q 631 322 621 322 L 565 322 Q 555 322 555 332 L 555 373 Q 555 383 565 382.93 L 579.53 382.82"
+        <path class="arrow command-dispatcher-aggregate-repo"
+              d="M 631.29 281.57 L 631.07 312 Q 631 322 621 322 L 565 322 Q 555 322 555 332 L 555 373 Q 555 383 565 382.93 L 579.53 382.82"
               fill="none" stroke="#0066cc" stroke-width="4" stroke-miterlimit="10"
               pointer-events="none"/>
-        <path class="arrow command-dispatcher-aggregate-repo" d="M 589.53 382.75 L 579.55 386.15 L 579.5 379.49 Z" fill="#0066cc" stroke="#0066cc"
+        <path class="arrow command-dispatcher-aggregate-repo"
+              d="M 589.53 382.75 L 579.55 386.15 L 579.5 379.49 Z" fill="#0066cc" stroke="#0066cc"
               stroke-width="4" stroke-miterlimit="10" pointer-events="none"/>
 
-        <rect class="rect system-context-bottom" x="566" y="888" width="350" height="150" fill="none" stroke="#cfcfcf" stroke-width="2"
+        <rect class="rect system-context-bottom" x="566" y="888" width="350" height="150"
+              fill="none" stroke="#cfcfcf" stroke-width="2"
               stroke-dasharray="6 6" pointer-events="none"/>
 
         <g class="g-caption aggregate-mirror" pointer-events="all">
@@ -373,14 +420,16 @@
                   fill="#97d077" stroke="none"
                   pointer-events="all"/>
             <g transform="translate(680.5,963.5)">
-                <text x="60" y="17" fill="#FFFFFF" text-anchor="middle" font-size="16px" pointer-events="all"
+                <text x="60" y="17" fill="#FFFFFF" text-anchor="middle" font-size="16px"
+                      pointer-events="all"
                       font-family="Helvetica" class="box-caption aggregate-mirror">
                     Aggregate Mirror
                 </text>
             </g>
         </g>
         <g transform="translate(684.5,900.5)">
-            <text x="56" y="17" fill="#999999" text-anchor="middle" font-size="16px" pointer-events="all"
+            <text x="56" y="17" fill="#999999" text-anchor="middle" font-size="16px"
+                  pointer-events="all"
                   font-family="Helvetica" class="box-caption system-context-bottom">
                 System Context
             </text>
@@ -398,7 +447,8 @@
                   stroke-width="2" pointer-events="all"/>
 
             <g transform="translate(660,484)">
-                <text x="0" y="0" fill="#808080" text-anchor="middle" font-size="16px" pointer-events="all"
+                <text x="0" y="0" fill="#808080" text-anchor="middle" font-size="16px"
+                      pointer-events="all"
                       font-family="Helvetica" class="box-caption pm-repo end-user">
                     <tspan x="0">Process</tspan>
                     <tspan x="0" dy="1.2em">Manager</tspan>
@@ -419,7 +469,8 @@
                   stroke-width="2" pointer-events="all"/>
 
             <g transform="translate(660,380)">
-                <text x="0" y="0" fill="#808080" text-anchor="middle" font-size="16px" pointer-events="all"
+                <text x="0" y="0" fill="#808080" text-anchor="middle" font-size="16px"
+                      pointer-events="all"
                       font-family="Helvetica" class="box-caption aggregate-repo end-user">
                     <tspan x="2">Aggregate</tspan>
                     <tspan x="0" dy="1.2em">Repository</tspan>
@@ -428,15 +479,19 @@
         </g>
 
         <g class="g-caption projection-repo" pointer-events="all">
-            <rect class="rect projection-repo layer-3 end-user" x="607.5" y="751.5" width="319" height="101" fill="#ffffff" stroke="#cfcfcf"
+            <rect class="rect projection-repo layer-3 end-user" x="607.5" y="751.5" width="319"
+                  height="101" fill="#ffffff" stroke="#cfcfcf"
                   stroke-width="2" pointer-events="all"/>
-            <rect class="rect projection-repo layer-2 end-user" x="603" y="747.5" width="319" height="101" fill="#ffffff" stroke="#cfcfcf"
+            <rect class="rect projection-repo layer-2 end-user" x="603" y="747.5" width="319"
+                  height="101" fill="#ffffff" stroke="#cfcfcf"
                   stroke-width="2" pointer-events="all"/>
-            <rect class="rect projection-repo layer-1 end-user" x="598.5" y="743" width="319" height="101" fill="#ffffff" stroke="#cfcfcf"
+            <rect class="rect projection-repo layer-1 end-user" x="598.5" y="743" width="319"
+                  height="101" fill="#ffffff" stroke="#cfcfcf"
                   stroke-width="2" pointer-events="all"/>
 
             <g transform="translate(660,790)">
-                <text x="0" y="0" fill="#808080" text-anchor="middle" font-size="16px"  pointer-events="all"
+                <text x="0" y="0" fill="#808080" text-anchor="middle" font-size="16px"
+                      pointer-events="all"
                       font-family="Helvetica" class="box-caption projection-repo end-user">
                     <tspan x="2">Projection</tspan>
                     <tspan x="0" dy="1.2em">Repository</tspan>
@@ -444,27 +499,36 @@
             </g>
         </g>
 
-        <path class="arrow stand-projection-repo" d="M 524.97 794 L 581.53 794" fill="none" stroke="#82b366" stroke-width="4"
+        <path class="arrow stand-projection-repo" d="M 524.97 794 L 581.53 794" fill="none"
+              stroke="#82b366" stroke-width="4"
               stroke-miterlimit="10" pointer-events="none"/>
-        <path class="arrow stand-projection-repo" d="M 517.47 794 L 527.47 790.67 L 524.97 794 L 527.47 797.33 Z" fill="#82b366"
+        <path class="arrow stand-projection-repo"
+              d="M 517.47 794 L 527.47 790.67 L 524.97 794 L 527.47 797.33 Z" fill="#82b366"
               stroke="#82b366" stroke-width="4" stroke-miterlimit="10" pointer-events="none"/>
-        <path class="arrow stand-projection-repo" d="M 591.53 794 L 581.53 797.33 L 581.53 790.67 Z" fill="#82b366" stroke="#82b366"
+        <path class="arrow stand-projection-repo" d="M 591.53 794 L 581.53 797.33 L 581.53 790.67 Z"
+              fill="#82b366" stroke="#82b366"
               stroke-width="4" stroke-miterlimit="10" pointer-events="none"/>
 
-        <path class="arrow stand-projection-repo" d="M 524.78 756 L 546 756 Q 556 756 556 746 L 556 529 Q 556 519 566 519.08 L 579.53 519.18"
+        <path class="arrow stand-projection-repo"
+              d="M 524.78 756 L 546 756 Q 556 756 556 746 L 556 529 Q 556 519 566 519.08 L 579.53 519.18"
               fill="none" stroke="#82b366" stroke-width="4" stroke-miterlimit="10"
               pointer-events="none"/>
-        <path class="arrow stand-pm-repo" d="M 517.28 756 L 527.28 752.67 L 524.78 756 L 527.28 759.33 Z" fill="#82b366"
+        <path class="arrow stand-pm-repo"
+              d="M 517.28 756 L 527.28 752.67 L 524.78 756 L 527.28 759.33 Z" fill="#82b366"
               stroke="#82b366" stroke-width="4" stroke-miterlimit="10" pointer-events="none"/>
-        <path class="arrow stand-pm-repo" d="M 589.53 519.25 L 579.5 522.51 L 579.55 515.84 Z" fill="#82b366" stroke="#82b366"
+        <path class="arrow stand-pm-repo" d="M 589.53 519.25 L 579.5 522.51 L 579.55 515.84 Z"
+              fill="#82b366" stroke="#82b366"
               stroke-width="4" stroke-miterlimit="10" pointer-events="none"/>
 
-        <path class="arrow stand-aggregate-mirror" d="M 587.5 956.69 L 566 956.9 Q 556 957 556 947 L 556 842 Q 556 832 546 832 L 527.76 832"
+        <path class="arrow stand-aggregate-mirror"
+              d="M 587.5 956.69 L 566 956.9 Q 556 957 556 947 L 556 842 Q 556 832 546 832 L 527.76 832"
               fill="none" stroke="#82b366" stroke-width="4" stroke-miterlimit="10"
               pointer-events="none"/>
-        <path class="arrow stand-aggregate-mirror" d="M 595 956.62 L 585.04 960.05 L 587.5 956.69 L 584.97 953.38 Z" fill="#82b366"
+        <path class="arrow stand-aggregate-mirror"
+              d="M 595 956.62 L 585.04 960.05 L 587.5 956.69 L 584.97 953.38 Z" fill="#82b366"
               stroke="#82b366" stroke-width="4" stroke-miterlimit="10" pointer-events="none"/>
-        <path class="arrow stand-aggregate-mirror" d="M 517.76 832 L 527.76 828.67 L 527.76 835.33 Z" fill="#82b366" stroke="#82b366"
+        <path class="arrow stand-aggregate-mirror"
+              d="M 517.76 832 L 527.76 828.67 L 527.76 835.33 Z" fill="#82b366" stroke="#82b366"
               stroke-width="4" stroke-miterlimit="10" pointer-events="none"/>
 
         <g class="g-arrow aggregate-states" pointer-events="all">
@@ -477,7 +541,8 @@
                   stroke="#82b366"
                   stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
             <g transform="translate(1145,338)">
-                <text x="0" y="0" fill="#009900" text-anchor="middle" font-size="14px" pointer-events="all"
+                <text x="0" y="0" fill="#009900" text-anchor="middle" font-size="14px"
+                      pointer-events="all"
                       font-family="Helvetica" class="arrow-caption aggregate-states">
                     <tspan x="2">Aggregate</tspan>
                     <tspan x="0" dy="1.2em">States</tspan>
@@ -490,7 +555,8 @@
                   ry="3.18" fill="#ffb366"
                   stroke="none" transform="rotate(90,784.5,608)" pointer-events="all"/>
             <g transform="translate(727.5,593.5)">
-                <text x="57" y="25" fill="#FFFFFF" text-anchor="middle" font-size="25px" pointer-events="all"
+                <text x="57" y="25" fill="#FFFFFF" text-anchor="middle" font-size="25px"
+                      pointer-events="all"
                       font-family="Helvetica" class="box-caption event-bus">
                     Event Bus
                 </text>
@@ -506,46 +572,56 @@
                   stroke="#ffffff"
                   stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
             <g transform="translate(1066.5,601.5)">
-                <text x="24" y="23" fill="#FFFFFF" text-anchor="middle" font-size="16px" pointer-events="all"
+                <text x="24" y="23" fill="#FFFFFF" text-anchor="middle" font-size="16px"
+                      pointer-events="all"
                       font-family="Helvetica" class="box-caption event-store">
                     Event Store
                 </text>
             </g>
         </g>
 
-        <path class="arrow aggregate-mirror-stand" d="M 601 987 L 524.24 987" fill="none" stroke="#82b366" stroke-width="2"
+        <path class="arrow aggregate-mirror-stand" d="M 601 987 L 524.24 987" fill="none"
+              stroke="#82b366" stroke-width="2"
               stroke-miterlimit="10" stroke-dasharray="6 6" pointer-events="none"/>
-        <path class="arrow aggregate-mirror-stand" d="M 518.24 987 L 526.24 984.33 L 524.24 987 L 526.24 989.67 Z" fill="#82b366"
+        <path class="arrow aggregate-mirror-stand"
+              d="M 518.24 987 L 526.24 984.33 L 524.24 987 L 526.24 989.67 Z" fill="#82b366"
               stroke="#82b366" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
 
-        <path class="arrow stand-subscription-service" d="M 460 987 L 347.89 987" fill="none" stroke="#82b366" stroke-width="2"
+        <path class="arrow stand-subscription-service" d="M 460 987 L 347.89 987" fill="none"
+              stroke="#82b366" stroke-width="2"
               stroke-miterlimit="10" stroke-dasharray="6 6" pointer-events="none"/>
-        <path class="arrow stand-subscription-service" d="M 341.89 987 L 349.89 984.33 L 347.89 987 L 349.89 989.67 Z" fill="#82b366"
+        <path class="arrow stand-subscription-service"
+              d="M 341.89 987 L 349.89 984.33 L 347.89 987 L 349.89 989.67 Z" fill="#82b366"
               stroke="#82b366" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
 
         <g transform="translate(960,950)">
-            <text x="0" y="0" fill="#009900" text-anchor="middle" font-size="14px" pointer-events="all"
+            <text x="0" y="0" fill="#009900" text-anchor="middle" font-size="14px"
+                  pointer-events="all"
                   font-family="Helvetica" class="arrow-caption aggregate-states">
                 <tspan x="2">Aggregate</tspan>
                 <tspan x="0" dy="1.2em">States</tspan>
             </text>
         </g>
 
-        <path class="path write-side brace end-user" d="M 1251 122 L 1236.25 122 Q 1226.25 122 1226.25 132 L 1226.25 347 Q 1226.25 357 1216.25 357 L 1211.13 357 Q 1206 357 1216 357 L 1221.13 357 Q 1226.25 357 1226.25 367 L 1226.25 582 Q 1226.25 592 1236.25 592 L 1251 592"
+        <path class="path write-side brace end-user"
+              d="M 1251 122 L 1236.25 122 Q 1226.25 122 1226.25 132 L 1226.25 347 Q 1226.25 357 1216.25 357 L 1211.13 357 Q 1206 357 1216 357 L 1221.13 357 Q 1226.25 357 1226.25 367 L 1226.25 582 Q 1226.25 592 1236.25 592 L 1251 592"
               fill="none" stroke="#cfcfcf" stroke-width="3" stroke-miterlimit="10"
               transform="rotate(180,1228.5,357)" pointer-events="none"/>
-        <path class="path read-side brace end-user" d="M 1251 612 L 1236.25 612 Q 1226.25 612 1226.25 622 L 1226.25 827 Q 1226.25 837 1216.25 837 L 1211.13 837 Q 1206 837 1216 837 L 1221.13 837 Q 1226.25 837 1226.25 847 L 1226.25 1052 Q 1226.25 1062 1236.25 1062 L 1251 1062"
+        <path class="path read-side brace end-user"
+              d="M 1251 612 L 1236.25 612 Q 1226.25 612 1226.25 622 L 1226.25 827 Q 1226.25 837 1216.25 837 L 1211.13 837 Q 1206 837 1216 837 L 1221.13 837 Q 1226.25 837 1226.25 847 L 1226.25 1052 Q 1226.25 1062 1236.25 1062 L 1251 1062"
               fill="none" stroke="#cfcfcf" stroke-width="3" stroke-miterlimit="10"
               transform="rotate(180,1228.5,837)" pointer-events="none"/>
 
         <g transform="translate(1217.5,351.5)rotate(-90,44.5,11)">
-            <text x="45" y="21" fill="#CFCFCF" text-anchor="middle" font-size="20px" pointer-events="all"
+            <text x="45" y="21" fill="#CFCFCF" text-anchor="middle" font-size="20px"
+                  pointer-events="all"
                   font-family="Helvetica" class="arrow-caption write-side end-user">
                 Write-side
             </text>
         </g>
         <g transform="translate(1216.5,831.5)rotate(-90,45.5,11)">
-            <text x="46" y="21" fill="#CFCFCF" text-anchor="middle" font-size="20px" pointer-events="all"
+            <text x="46" y="21" fill="#CFCFCF" text-anchor="middle" font-size="20px"
+                  pointer-events="all"
                   font-family="Helvetica" class="arrow-caption read-side end-user">
                 Read-side
             </text>
@@ -562,20 +638,25 @@
                   fill="#ffff99" stroke="#cfcfcf"
                   stroke-width="2" pointer-events="all"/>
             <g transform="translate(788.5,368.5)">
-                <text x="39" y="17" fill="#808080" text-anchor="middle" font-size="16px" pointer-events="all"
+                <text x="39" y="17" fill="#808080" text-anchor="middle" font-size="16px"
+                      pointer-events="all"
                       font-family="Helvetica" class="box-caption aggregate end-user">
                     Aggregate
                 </text>
             </g>
         </g>
-        <path class="arrow aggregate-repo-aggregate-commands end-user" d="M 719 376.67 L 756 376.93 Q 766 377 766.28 377.02 L 766.56 377.04" fill="none"
+        <path class="arrow aggregate-repo-aggregate-commands end-user"
+              d="M 719 376.67 L 756 376.93 Q 766 377 766.28 377.02 L 766.56 377.04" fill="none"
               stroke="#0066cc" stroke-width="4" stroke-miterlimit="10" pointer-events="none"/>
-        <path class="arrow aggregate-repo-aggregate-commands end-user" d="M 776.54 377.7 L 766.34 380.36 L 766.78 373.71 Z" fill="#0066cc" stroke="#0066cc"
+        <path class="arrow aggregate-repo-aggregate-commands end-user"
+              d="M 776.54 377.7 L 766.34 380.36 L 766.78 373.71 Z" fill="#0066cc" stroke="#0066cc"
               stroke-width="4" stroke-miterlimit="10" pointer-events="none"/>
 
-        <path class="arrow aggregate-event-bus" d="M 883.67 402.83 L 925 402.97 Q 935 403 934.97 413 L 934.54 564.19" fill="none"
+        <path class="arrow aggregate-event-bus"
+              d="M 883.67 402.83 L 925 402.97 Q 935 403 934.97 413 L 934.54 564.19" fill="none"
               stroke="#ff8000" stroke-width="4" stroke-miterlimit="10" pointer-events="none"/>
-        <path class="arrow aggregate-event-bus" d="M 934.51 574.19 L 931.21 564.19 L 937.87 564.2 Z" fill="#ff8000" stroke="#ff8000"
+        <path class="arrow aggregate-event-bus" d="M 934.51 574.19 L 931.21 564.19 L 937.87 564.2 Z"
+              fill="#ff8000" stroke="#ff8000"
               stroke-width="4" stroke-miterlimit="10" pointer-events="none"/>
 
         <g class="g-arrow event-bus-aggregate-repo" pointer-events="all">
@@ -588,16 +669,19 @@
                   stroke="#ff8000"
                   stroke-width="4" stroke-miterlimit="10" pointer-events="all"/>
             <g transform="translate(958.5,405.5)">
-                <text x="22" y="14" fill="#FF8000" text-anchor="middle" font-size="14px" pointer-events="all"
+                <text x="22" y="14" fill="#FF8000" text-anchor="middle" font-size="14px"
+                      pointer-events="all"
                       font-family="Helvetica" class="arrow-caption event-bus-aggregate-repo">
                     Events
                 </text>
             </g>
         </g>
 
-        <path class="arrow aggregate-repo-aggregate-events end-user" d="M 719 391.67 L 756 391.93 Q 766 392 766.28 392.02 L 766.56 392.04" fill="none"
+        <path class="arrow aggregate-repo-aggregate-events end-user"
+              d="M 719 391.67 L 756 391.93 Q 766 392 766.28 392.02 L 766.56 392.04" fill="none"
               stroke="#ff8000" stroke-width="4" stroke-miterlimit="10" pointer-events="none"/>
-        <path class="arrow aggregate-repo-aggregate-events end-user" d="M 776.54 392.7 L 766.34 395.36 L 766.78 388.71 Z" fill="#ff8000" stroke="#ff8000"
+        <path class="arrow aggregate-repo-aggregate-events end-user"
+              d="M 776.54 392.7 L 766.34 395.36 L 766.78 388.71 Z" fill="#ff8000" stroke="#ff8000"
               stroke-width="4" stroke-miterlimit="10" pointer-events="none"/>
 
         <g class="g-caption pm" pointer-events="all">
@@ -612,7 +696,8 @@
                   stroke-width="2" pointer-events="all"/>
 
             <g transform="translate(830,492)">
-                <text x="0" y="0" fill="#808080" text-anchor="middle" font-size="16px" pointer-events="all"
+                <text x="0" y="0" fill="#808080" text-anchor="middle" font-size="16px"
+                      pointer-events="all"
                       font-family="Helvetica" class="box-caption pm end-user">
                     <tspan x="2">Process</tspan>
                     <tspan x="0" dy="1.2em">Manager</tspan>
@@ -620,30 +705,40 @@
             </g>
         </g>
 
-        <path class="arrow pm-command-bus end-user" d="M 814.71 533 L 814.9 553 Q 815 563 805 563 L 636 563 Q 626 563 616 563 L 528.47 563"
+        <path class="arrow pm-command-bus end-user"
+              d="M 814.71 533 L 814.9 553 Q 815 563 805 563 L 636 563 Q 626 563 616 563 L 528.47 563"
               fill="none" stroke="#0066cc" stroke-width="4" stroke-miterlimit="10"
               pointer-events="none"/>
-        <path class="arrow pm-command-bus end-user" d="M 518.47 563 L 528.47 559.67 L 528.47 566.33 Z" fill="#0066cc" stroke="#0066cc"
+        <path class="arrow pm-command-bus end-user"
+              d="M 518.47 563 L 528.47 559.67 L 528.47 566.33 Z" fill="#0066cc" stroke="#0066cc"
               stroke-width="4" stroke-miterlimit="10" pointer-events="none"/>
 
-        <path class="arrow pm-repo-pm-commands end-user" d="M 719 488.67 L 756 488.93 Q 766 489 766.28 489.02 L 766.56 489.04" fill="none"
+        <path class="arrow pm-repo-pm-commands end-user"
+              d="M 719 488.67 L 756 488.93 Q 766 489 766.28 489.02 L 766.56 489.04" fill="none"
               stroke="#0066cc" stroke-width="4" stroke-miterlimit="10" pointer-events="none"/>
-        <path class="arrow pm-repo-pm-commands end-user" d="M 776.54 489.7 L 766.34 492.36 L 766.78 485.71 Z" fill="#0066cc" stroke="#0066cc"
+        <path class="arrow pm-repo-pm-commands end-user"
+              d="M 776.54 489.7 L 766.34 492.36 L 766.78 485.71 Z" fill="#0066cc" stroke="#0066cc"
               stroke-width="4" stroke-miterlimit="10" pointer-events="none"/>
 
-        <path class="arrow pm-repo-pm-events end-user" d="M 719 503.67 L 756 503.93 Q 766 504 766.28 504.02 L 766.56 504.04" fill="none"
+        <path class="arrow pm-repo-pm-events end-user"
+              d="M 719 503.67 L 756 503.93 Q 766 504 766.28 504.02 L 766.56 504.04" fill="none"
               stroke="#ff8000" stroke-width="4" stroke-miterlimit="10" pointer-events="none"/>
-        <path class="arrow pm-repo-pm-events end-user" d="M 776.54 504.7 L 766.34 507.36 L 766.78 500.71 Z" fill="#ff8000" stroke="#ff8000"
+        <path class="arrow pm-repo-pm-events end-user"
+              d="M 776.54 504.7 L 766.34 507.36 L 766.78 500.71 Z" fill="#ff8000" stroke="#ff8000"
               stroke-width="4" stroke-miterlimit="10" pointer-events="none"/>
 
-        <path class="arrow pm-event-bus" d="M 843 533 L 843 565.53" fill="none" stroke="#ff8000" stroke-width="4"
+        <path class="arrow pm-event-bus" d="M 843 533 L 843 565.53" fill="none" stroke="#ff8000"
+              stroke-width="4"
               stroke-miterlimit="10" pointer-events="none"/>
-        <path class="arrow pm-event-bus" d="M 843 575.53 L 839.67 565.53 L 846.33 565.53 Z" fill="#ff8000" stroke="#ff8000"
+        <path class="arrow pm-event-bus" d="M 843 575.53 L 839.67 565.53 L 846.33 565.53 Z"
+              fill="#ff8000" stroke="#ff8000"
               stroke-width="4" stroke-miterlimit="10" pointer-events="none"/>
 
-        <path class="arrow event-bus-pm-repo" d="M 861 582 L 861 564.47" fill="none" stroke="#ff8000" stroke-width="4"
+        <path class="arrow event-bus-pm-repo" d="M 861 582 L 861 564.47" fill="none"
+              stroke="#ff8000" stroke-width="4"
               stroke-miterlimit="10" pointer-events="none"/>
-        <path class="arrow event-bus-pm-repo" d="M 861 554.47 L 864.33 564.47 L 857.67 564.47 Z" fill="#ff8000" stroke="#ff8000"
+        <path class="arrow event-bus-pm-repo" d="M 861 554.47 L 864.33 564.47 L 857.67 564.47 Z"
+              fill="#ff8000" stroke="#ff8000"
               stroke-width="4" stroke-miterlimit="10" pointer-events="none"/>
 
         <g class="g-arrow command-service-ui" pointer-events="all">
@@ -654,16 +749,19 @@
                   d="M 182.47 271 L 192.47 267.67 L 192.47 274.33 Z" fill="#0066cc" stroke="#0066cc"
                   stroke-width="4" stroke-miterlimit="10" pointer-events="all"/>
             <g transform="translate(216.5,250.5)">
-                <text x="15" y="14" fill="#0066CC" text-anchor="middle" font-size="14px" pointer-events="all"
+                <text x="15" y="14" fill="#0066CC" text-anchor="middle" font-size="14px"
+                      pointer-events="all"
                       font-family="Helvetica" class="arrow-caption command-service-ui end-user">
                     Acks
                 </text>
             </g>
         </g>
 
-        <path class="arrow command-bus-command-service" d="M 460 271 L 354.47 271" fill="none" stroke="#0066cc" stroke-width="4"
+        <path class="arrow command-bus-command-service" d="M 460 271 L 354.47 271" fill="none"
+              stroke="#0066cc" stroke-width="4"
               stroke-miterlimit="10" pointer-events="none"/>
-        <path class="arrow command-bus-command-service" d="M 344.47 271 L 354.47 267.67 L 354.47 274.33 Z" fill="#0066cc" stroke="#0066cc"
+        <path class="arrow command-bus-command-service"
+              d="M 344.47 271 L 354.47 267.67 L 354.47 274.33 Z" fill="#0066cc" stroke="#0066cc"
               stroke-width="4" stroke-miterlimit="10" pointer-events="none"/>
 
         <g class="g-caption projection" pointer-events="all">
@@ -678,15 +776,18 @@
                   stroke-width="2" pointer-events="all"/>
 
             <g transform="translate(795.5,779.5)">
-                <text x="36" y="17" fill="#FFFFFF" text-anchor="middle" font-size="16px" pointer-events="all"
+                <text x="36" y="17" fill="#FFFFFF" text-anchor="middle" font-size="16px"
+                      pointer-events="all"
                       font-family="Helvetica" class="box-caption projection end-user">
                     Projection
                 </text>
             </g>
         </g>
-        <path class="arrow projection-repo-projection-events end-user" d="M 719 794 L 772.53 794" fill="none" stroke="#ff8000" stroke-width="4"
+        <path class="arrow projection-repo-projection-events end-user" d="M 719 794 L 772.53 794"
+              fill="none" stroke="#ff8000" stroke-width="4"
               stroke-miterlimit="10" pointer-events="none"/>
-        <path class="arrow projection-repo-projection-events end-user" d="M 782.53 794 L 772.53 797.33 L 772.53 790.67 Z" fill="#ff8000" stroke="#ff8000"
+        <path class="arrow projection-repo-projection-events end-user"
+              d="M 782.53 794 L 772.53 797.33 L 772.53 790.67 Z" fill="#ff8000" stroke="#ff8000"
               stroke-width="4" stroke-miterlimit="10" pointer-events="none"/>
     </g>
 </svg>

--- a/js/architecture-diagram.js
+++ b/js/architecture-diagram.js
@@ -95,7 +95,7 @@ $(
                         || hasClass(item, arrowCaptionClass)
                         || hasClass(item, titleCaptionClass)) {
 
-                        item.attr(fillOpacityAttr, elementOpacity);
+                        item.attr(fillOpacityAttr, textOpacity);
                     }
                 }
                 if (rectTag === elementName) {
@@ -243,7 +243,7 @@ $(
          * Displays the user-facing components and fades out the rest.
          */
         function displayUserFacing() {
-            fade("0.5", "0.3");
+            fade("0.65", "0.3");
             enableLink(allComponentLink, displayAll);
             disableLink(useFacingLink);
         }

--- a/js/architecture-diagram.js
+++ b/js/architecture-diagram.js
@@ -34,13 +34,10 @@ $(
         let selectedElementColor = "#8d28e0";
         let selectedCaptionColor = "#fafafa";
 
-        const originColorAttr = "origin-color";
         const originFillAttr = "origin-fill";
         const originStrokeAttr = "origin-stroke";
 
-        const colorProp = "color";
         const fillAttr = "fill";
-        const opacityAttr = "opacity";
         const strokeAttr = "stroke";
         const fillOpacityAttr = "fill-opacity";
         const strokeOpacityAttr = "stroke-opacity";


### PR DESCRIPTION
This PR slightly modifies the SVG diagram and the related JS file by removing the unused attributes and reformatting the code. Also, the opacity of the text in "faded" mode has been changed to look better.