### PR TITLE
Text and formatting fixes of Reference and Examples pages

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -5,9 +5,9 @@ bodyclass: docs
 layout: docs
 type: markdown
 ---
-<p>Here are some example apps to help developers with certain aspects of the framework.
-If&nbsp;you&nbsp;want&nbsp;to see a bigger picture of a Spine-based application, have a look at
-<a target="_blank" href="https://github.com/SpineEventEngine/todo-list">ToDo List</a>.</p>
+<p>Here are some example apps to familiarize with certain aspects of the framework.
+If&nbsp;you&nbsp;want&nbsp;to see a bigger picture of a Spine-based application, have a look at our
+<a target="_blank" href="https://github.com/SpineEventEngine/todo-list">ToDo List</a> example.</p>
 
 ## Java
 <ul>
@@ -17,8 +17,8 @@ If&nbsp;you&nbsp;want&nbsp;to see a bigger picture of a Spine-based application,
 
 ## JavaScript
 
-- TBD
+<p class="coming-soon">Coming soon...</p>
 
 ## C++
 
-- TBD
+<p class="coming-soon">Coming soon...</p>

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -1,7 +1,7 @@
 ---
 bodyclass: docs
 title: Reference
-headline: 'Language Specific API Reference'
+headline: 'Language-specific API Reference'
 layout: docs
 bodyclass: docs
 ---
@@ -10,8 +10,8 @@ bodyclass: docs
     <div class="container-fluid content-holder">
         <div class="row">
             <div class="col-md-7">
-                <p class="lead">Links to the language-specific automatically generated
-                    API&nbsp;reference documentation.</p>
+                <p>This section of Spine documentation contains links&nbsp; to the language-specific automatically generated
+                    API reference.</p>
             </div>
 
             <div class="lang-card-selector col-md-12 display-flex">


### PR DESCRIPTION
This is a PR to improve the content of `Reference` and `Example` index pages. 
In both files the following adjustments were made to introduction phrases: 
- Revision and editing.
- Formatting style changed to paragraph style to conform to other Docs pages formatting style.
In addition to it, 
-  API Reference page name fixed to `Language-specific API Reference`.
-  in Examples section changed the `TBD` to `Coming soon` style.  

TODO: web designer's help is needed for API index page css style adjustments. 