### PR TITLE
Changes to Command Handler concept

### DIFF
--- a/docs/concepts/command-handler.md
+++ b/docs/concepts/command-handler.md
@@ -12,7 +12,7 @@ Command Handler is an object which receives commands, modifies the state of the 
 
 ```
 final class TaskAggregate
-    extends Aggregate&lt;TaskId, Task, TaskVBuilder&gt; {
+    extends Aggregate<TaskId, Task, TaskVBuilder> {
     ...
     @Assign
     TaskCreated handle(CreateTask cmd, CommandContext ctx) {
@@ -26,4 +26,8 @@ final class TaskAggregate
     ...
 }
 ```
+<p class="note">[Aggregate](https://spine.io/docs/concepts/aggregate.html) is an example of such classes. 
+Objects can be `Aggregate`, `ProcessManager` and others inheriting `AbstractCommandHandler`. 
+All above-mentioned classes implement `CommandHandler` interface.</p>
+
 For more details, refer to [Java](/java/index.md) section.


### PR DESCRIPTION
Made the following changes to `command-handler.md` file:

- Added a note Aggregate being an example of classes used in Command Handler example; 
- Fixed example formatting issue.