### PR TITLE
Add `IntegrationEvent` concept

### DIFF
--- a/_includes/doc-side-concepts-nav.html
+++ b/_includes/doc-side-concepts-nav.html
@@ -28,12 +28,12 @@
         <ul class="doc-side-nav-inside">
             <li><h6 class="doc-side-nav-sub-title">Architecture</h6></li>
             <li><a href="{{ site.baseurl }}/docs/concepts/bounded-context.html" {% if current[3] == 'bounded-context.html' %}class='current'{% endif %}>Bounded Context</a></li>
-            <li><a href="{{ site.baseurl }}/docs/concepts/integration-event.html" {% if current[3] == 'integration-event.html' %}class='current'{% endif %}>Integration Event</a></li>
             <li><a href="{{ site.baseurl }}/docs/concepts/command-bus.html" {% if current[3] == 'command-bus.html' %}class='current'{% endif %}>Command Bus</a></li>
             <li><a href="{{ site.baseurl }}/docs/concepts/command-store.html" {% if current[3] == 'command-store.html' %}class='current'{% endif %}>Command Store</a></li>
             <li><a href="{{ site.baseurl }}/docs/concepts/command-service.html" {% if current[3] == 'command-service.html' %}class='current'{% endif %}>Command Service</a></li>
             <li><a href="{{ site.baseurl }}/docs/concepts/event-bus.html" {% if current[3] == 'event-bus.html' %}class='current'{% endif %}>Event Bus</a></li>
             <li><a href="{{ site.baseurl }}/docs/concepts/event-store.html" {% if current[3] == 'event-store.html' %}class='current'{% endif %}>Event Store</a></li>
+            <li><a href="{{ site.baseurl }}/docs/concepts/integration-event.html" {% if current[3] == 'integration-event.html' %}class='current'{% endif %}>Integration Event</a></li>
             <li><a href="{{ site.baseurl }}/docs/concepts/aggregate-mirror.html" {% if current[3] == 'aggregate-mirror.html' %}class='current'{% endif %}>Aggregate Mirror</a></li>
             <li><a href="{{ site.baseurl }}/docs/concepts/stand.html" {% if current[3] == 'stand.html' %}class='current'{% endif %}>Stand</a></li>
             <li><a href="{{ site.baseurl }}/docs/concepts/query-service.html" {% if current[3] == 'query-service.html' %}class='current'{% endif %}>Query Service</a></li>

--- a/docs/concepts/integration-event.md
+++ b/docs/concepts/integration-event.md
@@ -11,4 +11,3 @@ type: markdown
 Integration Events are <a href="{{ site.baseurl }}/docs/concepts/event.html">Events</a> used to communicate between different Bounded Contexts. 
 
 In Spine, every domain Event may become an Integration Event, if it is emitted by the given Bounded Context and consumed by other Bounded Contexts. 
-

--- a/docs/concepts/integration-event.md
+++ b/docs/concepts/integration-event.md
@@ -8,7 +8,7 @@ type: markdown
 ---
 <h2 class="top">Integration Event</h2> 
 
-Integration Events are Events used to communicate between different Bounded Contexts. 
+Integration Events are <a href="{{ site.baseurl }}/docs/concepts/event.html">Events</a> used to communicate between different Bounded Contexts. 
 
 In Spine, every domain Event may become an Integration Event, if it is emitted by the given Bounded Context and consumed by other Bounded Contexts. 
 

--- a/docs/concepts/integration-event.md
+++ b/docs/concepts/integration-event.md
@@ -7,4 +7,8 @@ sidenav: doc-side-concepts-nav.html
 type: markdown
 ---
 <h2 class="top">Integration Event</h2> 
-<p class="coming-soon">Integration Event concept to be added soon.</p>
+
+Integration Events are Events used to communicate between different Bounded Contexts. 
+
+In Spine, every domain Event may become an Integration Event, if it is emitted by the given Bounded Context and consumed by other Bounded Contexts. 
+


### PR DESCRIPTION
This changeset updates the "Integration Event" page with some content.

Also, an order of the items in the "Concepts" navigation bar was changed to put "Integration Event" lower than the more important concepts such as "Command Bus".

This PR addresses #154.