### PR TITLE
Hide a `toc` functionality if a page has less than 3 sub-headers

### DIFF
--- a/_includes/doc-side-concepts-nav.html
+++ b/_includes/doc-side-concepts-nav.html
@@ -1,7 +1,7 @@
 <ul class="doc-side-nav doc-side-nav-concepts">
     {% assign current = page.url | downcase | split: '/' %}
     <li><h5 class="doc-side-nav-title">Concepts</h5></li>
-    <li><a id="side-nav-parent-item" href="{{ site.baseurl }}/docs/concepts" {% if current[2] == 'concepts' %}class='current'{% endif %}>Architecture Overview</a></li>
+    <li><a href="{{ site.baseurl }}/docs/concepts" {% if current[2] == 'concepts' and current[3] == null %}class='current'{% endif %}>Architecture Overview</a></li>
     <li>
         <ul class="doc-side-nav-inside">
             <li><h6 class="doc-side-nav-sub-title">Messaging</h6></li>

--- a/_includes/doc-side-quickstart-nav.html
+++ b/_includes/doc-side-quickstart-nav.html
@@ -1,11 +1,7 @@
 <ul class="doc-side-nav">
     {% assign current = page.url | downcase | split: '/' %}
     <li><h5 class="doc-side-nav-title">Quick Start Guides</h5></li>
-    <li>
-        <ul class="doc-side-nav-inside">
-            <li><a href="{{ site.baseurl }}/docs/quickstart/java.html" {% if current[3] == 'java.html' %}class='current'{% endif %}>Java</a></li>
-            <li><a href="{{ site.baseurl }}/docs/quickstart/javascript.html" {% if current[3] == 'javascript.html' %}class='current'{% endif %}>JavaScript</a></li>
-            <li><a href="{{ site.baseurl }}/docs/quickstart/cpp.html" {% if current[3] == 'cpp.html' %}class='current'{% endif %}>C++</a></li>
-        </ul>
-    </li>
+    <li><a href="{{ site.baseurl }}/docs/quickstart/java.html" {% if current[3] == 'java.html' %}class='current'{% endif %}>Java</a></li>
+    <li><a href="{{ site.baseurl }}/docs/quickstart/javascript.html" {% if current[3] == 'javascript.html' %}class='current'{% endif %}>JavaScript</a></li>
+    <li><a href="{{ site.baseurl }}/docs/quickstart/cpp.html" {% if current[3] == 'cpp.html' %}class='current'{% endif %}>C++</a></li>
 </ul>

--- a/_includes/doc-side-tutorial-nav.html
+++ b/_includes/doc-side-tutorial-nav.html
@@ -1,7 +1,7 @@
 <ul class="doc-side-nav doc-side-nav-tutorial">
     {% assign current = page.url | downcase | split: '/' %}
     <li><h5 class="doc-side-nav-title">Tutorials</h5></li>
-    <li><a id="side-nav-parent-item" href="{{ site.baseurl }}/docs/tutorials" {% if current[2] == 'tutorials' %}class='current'{% endif %}>Overview</a></li>
+    <li><a href="{{ site.baseurl }}/docs/tutorials" {% if current[2] == 'tutorials' and current[3] == null %}class='current'{% endif %}>Overview</a></li>
     <li>
         <ul class="doc-side-nav-inside">
             <li><h6 class="doc-side-nav-sub-title">Basic</h6></li>

--- a/js/common.js
+++ b/js/common.js
@@ -34,8 +34,7 @@ var tocNavFixedPosition = 120; // Sticky TOC offset
 $(function() {
     expandItemOnHashChange();
     preventDefaultScroll();
-    hideTocTocify();
-    tocTocifySettings();
+    initTocTocify();
     showScrollTopBtn();
 });
 
@@ -64,21 +63,23 @@ $(window).resize(function() {
 });
 
 /**
- * Hides `toc` navigation if a page has less than 3 headers.
+ * Inits `toc` navigation if a page has more than 2 headers.
+ *
+ * @see {@link http://gregfranko.com/jquery.tocify.js/ Toc Tocify}
  */
-function hideTocTocify() {
+function initTocTocify() {
     const docsContainer = $(".docs-content");
     const headersQuantity = docsContainer.find("h2, h3, h4");
+    const topOffset = 12; // Offset from the `header` navigation
 
-    if (headersQuantity.length < 3 && tocNav.length) {
-        tocNav.css('display', 'none');
+    if (headersQuantity.length >= 3 && tocNav.length) {
+        tocNav.tocify({
+            selectors: "h2, h3, h4",
+            showAndHide: false,
+            scrollTo: initialHeadHeight + topOffset,
+            extendPage: false
+        });
     }
-}
-
-function tocTocifySettings() {
-    // Calls the tocify method on your HTML nav.
-    // InitialHeadHeight + 12 (12px — small offset from the header navigation)
-    tocNav.tocify({selectors:"h2, h3, h4", showAndHide: false, scrollTo: initialHeadHeight+12, extendPage: false});
 }
 
 // Fix TOC navigation on page while scrolling

--- a/js/common.js
+++ b/js/common.js
@@ -35,6 +35,7 @@ $(function() {
     switchDocSideNavItems();
     expandItemOnHashChange();
     preventDefaultScroll();
+    hideTocTocify();
     tocTocifySettings();
     showScrollTopBtn();
 });
@@ -68,6 +69,18 @@ function switchDocSideNavItems() {
     if ($('.doc-side-nav-inside a').hasClass('current')) {
         var element = document.getElementById('side-nav-parent-item');
         element.classList.remove('current');
+    }
+}
+
+/**
+ * Hides `toc` navigation if a page has less than 4 headers.
+ */
+function hideTocTocify() {
+    const docsContainer = $(".docs-content");
+    const headersQuantity = docsContainer.find("h2, h3, h4");
+
+    if (headersQuantity.length < 4 && tocNav.length) {
+        tocNav.css('display', 'none');
     }
 }
 

--- a/js/common.js
+++ b/js/common.js
@@ -72,7 +72,7 @@ function initTocTocify() {
     const headersQuantity = docsContainer.find("h2, h3, h4");
     const topOffset = 12; // Offset from the `header` navigation
 
-    if (headersQuantity.length >= 3 && tocNav.length) {
+    if (headersQuantity.length >= 3) {
         tocNav.tocify({
             selectors: "h2, h3, h4",
             showAndHide: false,

--- a/js/common.js
+++ b/js/common.js
@@ -73,13 +73,13 @@ function switchDocSideNavItems() {
 }
 
 /**
- * Hides `toc` navigation if a page has less than 4 headers.
+ * Hides `toc` navigation if a page has less than 3 headers.
  */
 function hideTocTocify() {
     const docsContainer = $(".docs-content");
     const headersQuantity = docsContainer.find("h2, h3, h4");
 
-    if (headersQuantity.length < 4 && tocNav.length) {
+    if (headersQuantity.length < 3 && tocNav.length) {
         tocNav.css('display', 'none');
     }
 }

--- a/js/common.js
+++ b/js/common.js
@@ -32,7 +32,6 @@ var tocNavFixedPosition = 120; // Sticky TOC offset
 
 
 $(function() {
-    switchDocSideNavItems();
     expandItemOnHashChange();
     preventDefaultScroll();
     hideTocTocify();
@@ -63,14 +62,6 @@ $(window).resize(function() {
     resizeTocHeightWithWindow();
     ifCookiesExist();
 });
-
-// Remove class from the parent element when the child is active
-function switchDocSideNavItems() {
-    if ($('.doc-side-nav-inside a').hasClass('current')) {
-        var element = document.getElementById('side-nav-parent-item');
-        element.classList.remove('current');
-    }
-}
 
 /**
  * Hides `toc` navigation if a page has less than 3 headers.


### PR DESCRIPTION
This PR closes #123.

In this PR I have added a new function that hides a `toc` functionality if a page has less than 3 sub-headers.

As part of the PR, I have also fixed a `doc-side` navigation and used a `Jekyll Liquid` to make sure that the current state matches the selected item in the `doc-side` navigation.