### PR TITLE
Use angle brackets for the generic parameters in the code example

### DIFF
--- a/docs/concepts/event-subsriber.md
+++ b/docs/concepts/event-subsriber.md
@@ -14,7 +14,7 @@ Here is a code example which shows how a method which handles this kind of messa
 
   ```
   final class TaskProjection
-      extends Projection&lt;TaskId, TaskItem, TaskItemVBuilder&gt; {
+      extends Projection<TaskId, TaskItem, TaskItemVBuilder> {
       ...
       @Subscribe
       void on(TaskCompleted e, EventContext ctx) {


### PR DESCRIPTION
In this PR I have used angle brackets for the generic parameters in the example code on the `Event Subscriber` page.