### PR TITLE
Fix `body` scroll jumping

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -95,6 +95,7 @@
 
   <!-- Include the common site javascript -->
   <script src="{{ site.baseurl }}/js/common.js" type="text/javascript" charset="utf-8"></script>
+  <script src="{{ site.baseurl }}/js/doc-side-nav.js" type="text/javascript" charset="utf-8"></script>
 
   <script src="{{ site.baseurl }}/js/cookiechoices.js"></script>
   <script src="{{ site.baseurl }}/js/cookies-init.js"></script>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -111,7 +111,7 @@
   </script>
 
   {% if page.customjs %}
-  <script  async="" defer="" type="text/javascript" src="{{ page.customjs }}"></script>
+    <script  async defer type="text/javascript" src="{{ page.customjs }}"></script>
   {% endif %}
 
 </body>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -111,7 +111,7 @@
   </script>
 
   {% if page.customjs %}
-    <script  async defer type="text/javascript" src="{{ page.customjs }}"></script>
+    <script defer type="text/javascript" src="{{ page.customjs }}"></script>
   {% endif %}
 
 </body>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -79,7 +79,9 @@
   <!-- Include all compiled plugins (below), or include individual files as needed -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-validate/1.15.0/jquery.validate.min.js"></script>
 
-  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js"
+          integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy"
+          crossorigin="anonymous"></script>
 
   <script src="{{ site.baseurl }}/js/jquery.visible.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-scrollTo/2.1.2/jquery.scrollTo.min.js"></script>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -40,4 +40,3 @@ bodyclass: docs
       {% endif %}
 
 <a onclick="topFunction()" id="go-top-btn" title="Go to Top"><span>Top</span></a>
-<script src="{{ site.baseurl }}/js/doc-side-nav.js" type="text/javascript" charset="utf-8"></script>

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -6,6 +6,7 @@ layout: docs
 type: markdown
 sidenav_list: concepts
 sidenav: doc-side-nav.html
+customjs: /js/architecture-diagram.js
 ---
 <h2 class="top">Architecture Overview</h2>
 <div id="toc" class="toc hide-block"></div>
@@ -15,8 +16,6 @@ This section introduces key concepts of Spine framework and its parts, helps you
 Below is an overall view of <span id="display-all-components">all Spine server components</span> and their relations. When developing with Spine, you will be interacting with <span id="display-user-facing-components">some of them</span>.
 
 <p>Select a component to navigate to its definition.</p>
-
-<script src="/js/architecture-diagram.js" type="text/javascript" charset="utf-8"></script>
 
 {% include_relative diagrams/spine-architecture-diagram.svg %}
 


### PR DESCRIPTION
This PR fixes #210.

This PR fixes a bug with appearing a `body` scroll on Windows.
It has happened because the custom js scripts were loaded before the `common.js`.
In this PR I have changed the order of the custom js scripts including and place them after the `common.js`.