### PR TITLE
Update document page layout

### DIFF
--- a/_includes/doc-nav.html
+++ b/_includes/doc-nav.html
@@ -1,16 +1,18 @@
-<div class="container-fluid content-holder nav-mobile-toggle">
-    <div class="row">
-        <div class="col-sm-12">
-            <ul class="doc-nav">
-                {% assign current = page.url | downcase | split: '/' %}
-                <li class="tab"><a href="{{ site.baseurl }}/docs/" {% if page.path == 'docs/index.html' %}class='current'{% endif %}>Home</a></li>
-                <li class="tab"><a href="{{ site.baseurl }}/docs/concepts" {% if current[2] == 'concepts' %}class='current'{% endif %}>Concepts</a></li>
-                <li class="tab"><a href="{{ site.baseurl }}/docs/quickstart" {% if current[2] == 'quickstart' %}class='current'{% endif %}>Quick Start</a></li>
-                <li class="tab"><a href="{{ site.baseurl }}/docs/guides" {% if current[2] == 'guides' %}class='current'{% endif %}>Guides</a></li>
-                <li class="tab"><a href="{{ site.baseurl }}/docs/tutorials" {% if current[2] == 'tutorials' %}class='current'{% endif %}>Tutorials</a></li>
-                <li class="tab"><a href="{{ site.baseurl }}/docs/reference" {% if current[2] == 'reference' %}class='current'{% endif %}>Reference</a></li>
-                <li class="tab"><a href="{{ site.baseurl }}/docs/examples" {% if current[2] == 'examples' %}class='current'{% endif %}>Examples</a></li>
-            </ul>
+<div class="top-doc-nav-container nav-mobile-toggle">
+    <div class="container-fluid content-holder">
+        <div class="row">
+            <div class="col-sm-12">
+                <ul class="doc-nav">
+                    {% assign current = page.url | downcase | split: '/' %}
+                    <li class="tab"><a href="{{ site.baseurl }}/docs/" {% if page.path == 'docs/index.html' %}class='current'{% endif %}>Home</a></li>
+                    <li class="tab"><a href="{{ site.baseurl }}/docs/concepts" {% if current[2] == 'concepts' %}class='current'{% endif %}>Concepts</a></li>
+                    <li class="tab"><a href="{{ site.baseurl }}/docs/quickstart" {% if current[2] == 'quickstart' %}class='current'{% endif %}>Quick Start</a></li>
+                    <li class="tab"><a href="{{ site.baseurl }}/docs/guides" {% if current[2] == 'guides' %}class='current'{% endif %}>Guides</a></li>
+                    <li class="tab"><a href="{{ site.baseurl }}/docs/tutorials" {% if current[2] == 'tutorials' %}class='current'{% endif %}>Tutorials</a></li>
+                    <li class="tab"><a href="{{ site.baseurl }}/docs/reference" {% if current[2] == 'reference' %}class='current'{% endif %}>Reference</a></li>
+                    <li class="tab"><a href="{{ site.baseurl }}/docs/examples" {% if current[2] == 'examples' %}class='current'{% endif %}>Examples</a></li>
+                </ul>
+            </div>
         </div>
     </div>
 </div>

--- a/_includes/doc-side-nav.html
+++ b/_includes/doc-side-nav.html
@@ -1,4 +1,4 @@
-<ul class="docs-side-nav sticky-element">
+<ul class="docs-side-nav">
     <div class="navigation-title-on-mobile">
         <div class="close-btn-wrapper">
             <a class="close-btn">

--- a/_includes/doc-side-nav.html
+++ b/_includes/doc-side-nav.html
@@ -1,4 +1,4 @@
-<ul class="docs-side-nav">
+<ul class="docs-side-nav sticky-element">
     <div class="navigation-title-on-mobile">
         <div class="close-btn-wrapper">
             <a class="close-btn">

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,4 +1,4 @@
-<header id="header" {% if page.header-type == 'fixed-dark-header' %}class='fixed-dark-header'{% endif %} >
+<header id="header" {% if page.header_type != null %}class='{{page.header_type}}'{% endif %} >
     <div class="nav-open-close">
         <div id="nav-icon-menu">
             <span></span>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,4 +1,7 @@
-<header id="header" {% if page.header_type != null %}class='{{page.header_type}}'{% endif %} >
+<header id="header"
+        {% if page.header_type != null %}class='{{ page.header_type }}'
+        {% else %}{%if layout.header_class != null %}class='{{ layout.header_class }}'{% endif %}
+        {% endif %} >
     <div class="nav-open-close">
         <div id="nav-icon-menu">
             <span></span>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -66,7 +66,7 @@
 
 </head>
 
-<body class={{page.bodyclass}}>
+<body class="{{ page.bodyclass }}">
   <div class="wrapper">
     <div class="main">
       {{ content }}

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -15,7 +15,7 @@ bodyclass: docs
                 <span>Contents</span>
             </div>
             <div class="col-12 col-lg side-nav-col docs-side-nav-holder">
-                {% include {{page.sidenav}} %}
+                {% include {{ page.sidenav }} %}
             </div>
             <div class="col-12 col-lg docs-content-text {{ page.type }}">
                 {{ content }}

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -2,6 +2,7 @@
 title: docs
 layout: default
 bodyclass: docs
+header_class: hide-sticky-header
 ---
 
 {% include doc-nav.html %}

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -14,11 +14,11 @@ bodyclass: docs
                     <i class="fas fa-list-ul"></i>
                     <span>Contents</span>
                 </div>
-                <div class="col-12 col-md-3 docs-side-nav-holder">
+                <div class="col-12 col-md side-nav-col docs-side-nav-holder">
                     {% include {{page.sidenav}} %}
                 </div>
-                <div class="col-12 col-md-6 mr-auto {{ page.type }}">
-                  {{ content }}
+                <div class="col-12 col-md docs-content-text {{ page.type }}">
+                    {{ content }}
                 </div>
                 <div class="col-md toc-col">
                     <div id="toc" class="toc"></div>
@@ -29,7 +29,7 @@ bodyclass: docs
           {% if page.type == 'markdown' %}
               <div class="container-fluid content-holder docs-content {{ page.type }}">
                 <div class="row">
-                    <div class="col-md-7">
+                    <div class="col-md-7 docs-content-text">
                         {{ content }}
                     </div>
                 </div>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -7,36 +7,36 @@ bodyclass: docs
 {% include doc-nav.html %}
 
 {% assign current = page.url | downcase | split: '/' %}
-      {% if current[1] == 'docs' and page.sidenav != null %}
-          <div class="container-fluid content-holder docs-content">
+{% if current[1] == 'docs' and page.sidenav != null %}
+    <div class="container-fluid content-holder docs-content">
+        <div class="row">
+            <div id="docs-side-nav-mobile-toggle">
+                <i class="fas fa-list-ul"></i>
+                <span>Contents</span>
+            </div>
+            <div class="col-12 col-md side-nav-col docs-side-nav-holder">
+                {% include {{page.sidenav}} %}
+            </div>
+            <div class="col-12 col-md docs-content-text {{ page.type }}">
+                {{ content }}
+            </div>
+            <div class="col-md toc-col">
+                <div id="toc" class="toc"></div>
+            </div>
+        </div>
+    </div>
+{% else %}
+    {% if page.type == 'markdown' %}
+        <div class="container-fluid content-holder docs-content {{ page.type }}">
             <div class="row">
-                <div id="docs-side-nav-mobile-toggle">
-                    <i class="fas fa-list-ul"></i>
-                    <span>Contents</span>
-                </div>
-                <div class="col-12 col-md side-nav-col docs-side-nav-holder">
-                    {% include {{page.sidenav}} %}
-                </div>
-                <div class="col-12 col-md docs-content-text {{ page.type }}">
+                <div class="col-md-7 docs-content-text">
                     {{ content }}
                 </div>
-                <div class="col-md toc-col">
-                    <div id="toc" class="toc"></div>
-                </div>
             </div>
-          </div>
-      {% else %}
-          {% if page.type == 'markdown' %}
-              <div class="container-fluid content-holder docs-content {{ page.type }}">
-                <div class="row">
-                    <div class="col-md-7 docs-content-text">
-                        {{ content }}
-                    </div>
-                </div>
-              </div>
-          {% else %}
-              {{ content }}
-          {% endif %}
-      {% endif %}
+        </div>
+    {% else %}
+        {{ content }}
+    {% endif %}
+{% endif %}
 
 <a onclick="topFunction()" id="go-top-btn" title="Go to Top"><span>Top</span></a>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -21,7 +21,7 @@ bodyclass: docs
                 {{ content }}
             </div>
             <div class="col-md toc-col">
-                <div id="toc" class="toc"></div>
+                <div id="toc" class="toc sticky-element"></div>
             </div>
         </div>
     </div>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -29,7 +29,7 @@ bodyclass: docs
     {% if page.type == 'markdown' %}
         <div class="container-fluid content-holder docs-content {{ page.type }}">
             <div class="row">
-                <div class="col-md-7 docs-content-text">
+                <div class="col-md-7">
                     {{ content }}
                 </div>
             </div>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -14,13 +14,13 @@ bodyclass: docs
                 <i class="fas fa-list-ul"></i>
                 <span>Contents</span>
             </div>
-            <div class="col-12 col-md side-nav-col docs-side-nav-holder">
+            <div class="col-12 col-lg side-nav-col docs-side-nav-holder">
                 {% include {{page.sidenav}} %}
             </div>
-            <div class="col-12 col-md docs-content-text {{ page.type }}">
+            <div class="col-12 col-lg docs-content-text {{ page.type }}">
                 {{ content }}
             </div>
-            <div class="col-md toc-col">
+            <div class="col-lg toc-col">
                 <div id="toc" class="toc sticky-element"></div>
             </div>
         </div>

--- a/_posts/2018-05-21-blog-is-now-live.md
+++ b/_posts/2018-05-21-blog-is-now-live.md
@@ -3,7 +3,7 @@ layout: post
 title: Blog is now live
 published: true
 bodyclass: post
-header-type: fixed-dark-header
+header_type: fixed-dark-header
 ---
 
 As we are getting closer to `1.0-GA` release of the framework we thought that it would be nice to start blogging about the framework development, the ES/CQRS-based projects, our insights etc.

--- a/_posts/2018-05-22-migrating-to-java-8.md
+++ b/_posts/2018-05-22-migrating-to-java-8.md
@@ -3,7 +3,7 @@ layout: post
 title: Migrating to Java 8
 published: true
 bodyclass: post
-header-type: fixed-dark-header
+header_type: fixed-dark-header
 ---
 
 Starting the upcoming `0.11.0` release the minimal version of Java for Spine-based application will become Java 8. Early adopters can already see the first sights of Java 8 migration in core framework modules.

--- a/_posts/2019-08-21-spine-event-engine-1-0-is-out.md
+++ b/_posts/2019-08-21-spine-event-engine-1-0-is-out.md
@@ -3,7 +3,7 @@ layout: post
 title: Spine Event Engine 1.0 is Out!
 published: true
 bodyclass: post
-header-type: fixed-dark-header
+header_type: fixed-dark-header
 ---
 
 We are glad to announce the release of the first production-ready version of Spine Event Engine!

--- a/_sass/base/_colors.scss
+++ b/_sass/base/_colors.scss
@@ -3,6 +3,7 @@ $mainBrandColor: #1a96de;
 $secondBrandColor: #116db4;
 $thirdBrandColor: #ddeaf4;
 $inverseBrandColor: #FFFFFF;
+$body-light-gray-color: #f6f8fA;
 
 // Dividers
 $dividerColor: rgba(0, 0, 0, .08);
@@ -20,7 +21,6 @@ $gray: #737373;
 $light-gray: lighten($gray, 52%);
 $light-gray-blue: #eef1f3;
 $dark-gray: darken($gray, 20%);
-
 
 $linkColor: $mainBrandColor;
 $linkHoverColor: darken($linkColor, 10%);

--- a/_sass/base/_common.scss
+++ b/_sass/base/_common.scss
@@ -169,7 +169,7 @@
 
   &.sticky {
     position:fixed;
-    margin-top: -140px;
+    margin-top: -154px;
   }
 }
 

--- a/_sass/base/_common.scss
+++ b/_sass/base/_common.scss
@@ -162,23 +162,25 @@
   }
 }
 
-.toc {
+.sticky-element {
   padding: 0;
   position: relative;
   overflow: auto;
   max-height: 80%;
   min-height: 100px;
-  width: 210px; // 210px = col-width - paddings; 210px = 240px - 15px - 15px
-  // Add this for the Chrome to fix jumping while scrolling
-  -webkit-transform: translateZ(0);
-
-  &.blog-toc {
-    margin: 40px 0 24px;
-  }
+  -webkit-transform: translateZ(0); // Fixes jumping while scrolling
 
   &.sticky {
     position:fixed;
     margin-top: -120px;
+  }
+}
+
+.toc {
+  width: 210px; // 210px = col-width - paddings; 210px = 240px - 15px - 15px
+
+  &.blog-toc {
+    margin: 40px 0 24px;
   }
 
   &.hide-block {

--- a/_sass/base/_common.scss
+++ b/_sass/base/_common.scss
@@ -167,7 +167,6 @@
   position: relative;
   overflow: auto;
   max-height: 80%;
-  min-height: 100px;
   -webkit-transform: translateZ(0); // Fixes jumping while scrolling
 
   &.sticky {

--- a/_sass/base/_common.scss
+++ b/_sass/base/_common.scss
@@ -161,15 +161,17 @@
 }
 
 .sticky-element {
-  padding: 0;
-  position: relative;
-  overflow: auto;
-  max-height: 80%;
-  -webkit-transform: translateZ(0); // Fixes jumping while scrolling
+  @media (min-width: $tablet-large) {
+    padding: 0;
+    position: relative;
+    overflow: auto;
+    max-height: 80%;
+    -webkit-transform: translateZ(0); // Fixes jumping while scrolling
 
-  &.sticky {
-    position:fixed;
-    margin-top: -154px;
+    &.sticky {
+      position: fixed;
+      margin-top: -154px; // The height of the `nav-hero-container`
+    }
   }
 }
 

--- a/_sass/base/_common.scss
+++ b/_sass/base/_common.scss
@@ -174,7 +174,7 @@
 }
 
 .toc {
-  width: 210px; // 210px = col-width - paddings; 210px = 240px - 15px - 15px
+  width: $sticky-el-width;
   padding-top: 12px;
 
   &.blog-toc {

--- a/_sass/base/_common.scss
+++ b/_sass/base/_common.scss
@@ -172,12 +172,13 @@
 
   &.sticky {
     position:fixed;
-    margin-top: -120px;
+    margin-top: -140px;
   }
 }
 
 .toc {
   width: 210px; // 210px = col-width - paddings; 210px = 240px - 15px - 15px
+  padding-top: 12px;
 
   &.blog-toc {
     margin: 40px 0 24px;

--- a/_sass/base/_common.scss
+++ b/_sass/base/_common.scss
@@ -148,6 +148,11 @@
   width: 100%;
 }
 
+.side-nav-col {
+  -ms-flex: 0 0 240px;
+  flex: 0 0 240px;
+}
+
 .toc-col {
   -ms-flex: 0 0 240px;
   flex: 0 0 240px;

--- a/_sass/base/_common.scss
+++ b/_sass/base/_common.scss
@@ -148,15 +148,13 @@
   width: 100%;
 }
 
+.toc-col,
 .side-nav-col {
   -ms-flex: 0 0 240px;
   flex: 0 0 240px;
 }
 
 .toc-col {
-  -ms-flex: 0 0 240px;
-  flex: 0 0 240px;
-
   @media (max-width: $desktop-small) {
     display: none;
   }

--- a/_sass/base/_config.scss
+++ b/_sass/base/_config.scss
@@ -64,3 +64,7 @@ $icon-size--xs              : 16px;
 $icon-size--s               : 24px;
 $icon-size--m               : 32px;
 $icon-size--l               : 40px;
+
+//Width for the element that is inside the custom column in 240px
+//Width equals `custom-column-width` minus `padding` (240px - 15px - 15px = 210px)
+$sticky-el-width: 210px;

--- a/_sass/base/_config.scss
+++ b/_sass/base/_config.scss
@@ -35,6 +35,7 @@ $phone-medium               : 480px;
 $phone-large                : 512px;
 $phone-xlarge               : 640px;
 $tablet                     : 768px;
+$tablet-large               : 991px;
 $desktop-small              : 1024px;
 $desktop-medium             : 1280px;
 $desktop-large              : 1440px;

--- a/_sass/base/_config.scss
+++ b/_sass/base/_config.scss
@@ -65,6 +65,6 @@ $icon-size--s               : 24px;
 $icon-size--m               : 32px;
 $icon-size--l               : 40px;
 
-//Width for the element that is inside the custom column in 240px
-//Width equals `custom-column-width` minus `padding` (240px - 15px - 15px = 210px)
+// Width for the element that is inside the custom column in 240px
+// Width equals `custom-column-width` minus `padding` (240px - 15px - 15px = 210px)
 $sticky-el-width: 210px;

--- a/_sass/base/_markdown.scss
+++ b/_sass/base/_markdown.scss
@@ -29,6 +29,10 @@
     padding-top: 0;
   }
 
+  h2 + div + h3 {
+    padding-top: 0;
+  }
+
   em {
     font-style: italic;
   }

--- a/_sass/base/_markdown.scss
+++ b/_sass/base/_markdown.scss
@@ -15,12 +15,13 @@
   }
 
   p + ul {
-    margin-top: -8px;
+    margin-top: -2px;
   }
 
   h1, h2, h3, h2 {
     code {
       font-size: inherit;
+      color: inherit;
     }
   }
 
@@ -56,6 +57,7 @@
       position: relative;
       margin-left: 18px;
       margin-bottom: 6px;
+      font-size: 1rem;
     }
   }
 
@@ -92,6 +94,8 @@
   // Section Headlines
   h2 {
     padding-top: 40px;
+    font-size: 1.875rem;
+    margin-bottom: 24px;
 
     &.top {
       padding-top: 8px;

--- a/_sass/base/_text.scss
+++ b/_sass/base/_text.scss
@@ -32,9 +32,13 @@ h3 {
   font-size: 1.25rem;
   color: $black;
   font-weight: 500;
-  padding-top: 22px;
-  margin-bottom: 12px;
+  padding-top: 24px;
+  margin-bottom: 16px;
   line-height: 1.4;
+}
+
+h2 + div + h3 {
+  padding-top: 0;
 }
 
 // Section Subheadlines

--- a/_sass/base/_text.scss
+++ b/_sass/base/_text.scss
@@ -37,10 +37,6 @@ h3 {
   line-height: 1.4;
 }
 
-h2 + div + h3 {
-  padding-top: 0;
-}
-
 // Section Subheadlines
 h4 {
   margin: 32px 0 8px;

--- a/_sass/modules/_doc-nav.scss
+++ b/_sass/modules/_doc-nav.scss
@@ -88,7 +88,7 @@ $top-doc-nav-margin: 20px 0 16px;
   margin-bottom: 40px;
   margin-left: -$nav-first-level-left-padding;
 
-  @media(max-width: $tablet){
+  @media(max-width: 767px){
     margin: 0;
   }
 
@@ -208,7 +208,7 @@ $top-doc-nav-margin: 20px 0 16px;
 #docs-side-nav-mobile-toggle {
   display: none;
 
-  @media(max-width: $tablet){
+  @media(max-width: 767px){
     display: block;
     padding: 0 15px;
     cursor: pointer;

--- a/_sass/modules/_doc-nav.scss
+++ b/_sass/modules/_doc-nav.scss
@@ -214,6 +214,7 @@ $top-doc-nav-margin: 20px 0 16px;
     cursor: pointer;
     color: $mainBrandColor;
     font-size: 15px;
+    margin-bottom: 24px;
 
     i {
       margin-right: 8px;

--- a/_sass/modules/_doc-nav.scss
+++ b/_sass/modules/_doc-nav.scss
@@ -223,7 +223,7 @@ $top-doc-nav-margin: 20px 0 16px;
   }
 
   @media (max-width: $phone-xlarge) {
-    margin-top: 24px;
+    margin: 24px 0 32px;
   }
 }
 

--- a/_sass/modules/_doc-nav.scss
+++ b/_sass/modules/_doc-nav.scss
@@ -19,6 +19,10 @@ $top-doc-nav-shadow: 0 2px 7px 0 rgba(0, 0, 0, .08);
 $top-doc-nav-margin: 20px 0 16px;
 
 .top-doc-nav-container {
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0;
+  z-index: 100;
   background-color: white;
   -webkit-box-shadow: $top-doc-nav-shadow;
   -moz-box-shadow: $top-doc-nav-shadow;

--- a/_sass/modules/_doc-nav.scss
+++ b/_sass/modules/_doc-nav.scss
@@ -96,6 +96,7 @@ $top-doc-nav-margin: 20px 0 16px;
 
   @media(max-width: $tablet-large){
     margin: 0;
+    width: 100%;
   }
 
   .side-nav-link {

--- a/_sass/modules/_doc-nav.scss
+++ b/_sass/modules/_doc-nav.scss
@@ -25,7 +25,7 @@ $top-doc-nav-margin: 20px 0 16px;
   -o-box-shadow: $top-doc-nav-shadow;
   box-shadow: $top-doc-nav-shadow;
 
-  @media(max-width: $tablet){
+  @media(max-width: $tablet-large){
     margin-bottom: 24px;
   }
 
@@ -88,7 +88,7 @@ $top-doc-nav-margin: 20px 0 16px;
   margin-bottom: 40px;
   margin-left: -$nav-first-level-left-padding;
 
-  @media(max-width: 767px){
+  @media(max-width: $tablet-large){
     margin: 0;
   }
 
@@ -208,7 +208,7 @@ $top-doc-nav-margin: 20px 0 16px;
 #docs-side-nav-mobile-toggle {
   display: none;
 
-  @media(max-width: 767px){
+  @media(max-width: $tablet-large){
     display: block;
     padding: 0 15px;
     cursor: pointer;
@@ -228,7 +228,7 @@ $top-doc-nav-margin: 20px 0 16px;
 }
 
 .docs-side-nav-holder {
-  @media(max-width: 767px) {
+  @media(max-width: $tablet-large) {
     z-index: 1001;
     display: none;
     position: fixed;

--- a/_sass/modules/_doc-nav.scss
+++ b/_sass/modules/_doc-nav.scss
@@ -9,6 +9,7 @@ $nav-link-chevron-size: 6px;
 $nav-first-level-left-padding: 24px;
 $nav-second-level-left-padding: calc(#{$nav-first-level-left-padding} + 16px);
 $nav-third-level-left-padding: calc(#{$nav-second-level-left-padding} + 16px);
+$sticky-docs-side-nav-width: $sticky-el-width + $nav-first-level-left-padding;
 
 // Navigation on mobile
 $nav-holder-padding: 32px 24px 32px 16px;
@@ -91,6 +92,7 @@ $top-doc-nav-margin: 20px 0 16px;
 .docs-side-nav {
   margin-bottom: 40px;
   margin-left: -$nav-first-level-left-padding;
+  width: $sticky-docs-side-nav-width;
 
   @media(max-width: $tablet-large){
     margin: 0;

--- a/_sass/modules/_doc-nav.scss
+++ b/_sass/modules/_doc-nav.scss
@@ -14,19 +14,31 @@ $nav-third-level-left-padding: calc(#{$nav-second-level-left-padding} + 16px);
 $nav-holder-padding: 32px 24px 32px 16px;
 $nav-title-left-padding: 22px;
 
-// Documentation Navigation Bar
-.nav-mobile-toggle {
-  @media (max-width: $phone-xlarge){
-    display: none;
+// Top navigation
+$top-doc-nav-shadow: 0 2px 7px 0 rgba(0, 0, 0, .08);
+$top-doc-nav-margin: 20px 0 16px;
+
+.top-doc-nav-container {
+  background-color: white;
+  -webkit-box-shadow: $top-doc-nav-shadow;
+  -moz-box-shadow: $top-doc-nav-shadow;
+  -o-box-shadow: $top-doc-nav-shadow;
+  box-shadow: $top-doc-nav-shadow;
+
+  @media(max-width: $tablet){
+    margin-bottom: 24px;
+  }
+
+  &.nav-mobile-toggle {
+    @media (max-width: $phone-xlarge){
+      display: none;
+    }
   }
 }
 
 .doc-nav {
   display: block;
-  margin: $spacing--m 0 $spacing--m;
-  @media(max-width: $tablet){
-    margin-bottom: 24px;
-  }
+  margin: $top-doc-nav-margin;
 
   .tab {
     display: inline-block;

--- a/_sass/modules/_doc-nav.scss
+++ b/_sass/modules/_doc-nav.scss
@@ -97,6 +97,7 @@ $top-doc-nav-margin: 20px 0 16px;
   @media(max-width: $tablet-large){
     margin: 0;
     width: 100%;
+    max-height: none !important; // Unset calculated max-height for the sticky element on mobile
   }
 
   .side-nav-link {
@@ -107,6 +108,10 @@ $top-doc-nav-margin: 20px 0 16px;
     color: $nav-link-color;
     font-weight: 400;
     @include transition(all .3s ease-in-out);
+
+    @media (max-width: $tablet-large) {
+      padding: 12px $nav-first-level-left-padding;
+    }
 
     // Tree title with chevron
     &.tree-title {
@@ -124,6 +129,10 @@ $top-doc-nav-margin: 20px 0 16px;
         left: 8px;
         transform: rotate(45deg);
         @include transition(all .3s ease-in-out);
+
+        @media (max-width: $tablet-large) {
+          top: 18px;
+        }
       }
 
       &.collapsed {
@@ -134,6 +143,10 @@ $top-doc-nav-margin: 20px 0 16px;
           border-bottom: $nav-link-chevron-border-size;
           top: 15px;
           transform: rotate(-45deg);
+
+          @media (max-width: $tablet-large) {
+            top: 19px;
+          }
         }
       }
     }

--- a/_sass/pages/_docs.scss
+++ b/_sass/pages/_docs.scss
@@ -1,13 +1,25 @@
 $docs-content-border: 1px solid #e6ecf1;
+$docs-content-padding: 32px 48px 56px;
+$docs-content-margin-bottom: 32px;
+$docs-content-border-radius: 3px;
 
 // Docs layout specific
 .docs {
   background-color: $body-light-gray-color;
+
   .docs-content {
     margin-top: 24px;
 
     @media (max-width: 767px) {
       margin-top: 0;
+    }
+
+    .docs-content-text {
+      background-color: $white;
+      border: $docs-content-border;
+      border-radius: $docs-content-border-radius;
+      padding: $docs-content-padding;
+      margin-bottom: $docs-content-margin-bottom;
     }
   }
 

--- a/_sass/pages/_docs.scss
+++ b/_sass/pages/_docs.scss
@@ -19,7 +19,7 @@ $docs-content-border-radius: 3px;
   .docs-content {
     margin-top: 24px;
 
-    @media (max-width: 767px) {
+    @media (max-width: $tablet-large) {
       margin-top: 0;
     }
 

--- a/_sass/pages/_docs.scss
+++ b/_sass/pages/_docs.scss
@@ -24,6 +24,7 @@ $docs-content-border-radius: 3px;
       border-radius: $docs-content-border-radius;
       padding: $docs-content-padding;
       margin-bottom: $docs-content-margin-bottom;
+      min-width:0 // Fixes a bug when `pre` code breaks flex element
     }
   }
 

--- a/_sass/pages/_docs.scss
+++ b/_sass/pages/_docs.scss
@@ -7,6 +7,10 @@ $docs-content-border-radius: 3px;
 .docs {
   background-color: $body-light-gray-color;
 
+  &.white-bg {
+    background-color: white;
+  }
+
   .docs-content {
     margin-top: 24px;
 

--- a/_sass/pages/_docs.scss
+++ b/_sass/pages/_docs.scss
@@ -50,7 +50,7 @@ $docs-content-border-radius: 3px;
   }
 
   .lang-card-selector {
-    padding: 0 0 88px;
+    padding: 8px 0 88px;
     width: 100%;
 
     @media(max-width: $phone-xlarge){

--- a/_sass/pages/_docs.scss
+++ b/_sass/pages/_docs.scss
@@ -4,7 +4,6 @@ $docs-content-padding-mobile: 0 15px;
 $docs-content-margin-bottom: 32px;
 $docs-content-border-radius: 3px;
 
-// Docs layout specific
 .docs {
   background-color: $body-light-gray-color;
 

--- a/_sass/pages/_docs.scss
+++ b/_sass/pages/_docs.scss
@@ -1,5 +1,8 @@
+$docs-content-border: 1px solid #e6ecf1;
+
 // Docs layout specific
 .docs {
+  background-color: $body-light-gray-color;
   .docs-content {
     margin-top: 24px;
 

--- a/_sass/pages/_docs.scss
+++ b/_sass/pages/_docs.scss
@@ -1,11 +1,16 @@
 $docs-content-border: 1px solid #e6ecf1;
 $docs-content-padding: 32px 48px 56px;
+$docs-content-padding-mobile: 0 15px;
 $docs-content-margin-bottom: 32px;
 $docs-content-border-radius: 3px;
 
 // Docs layout specific
 .docs {
   background-color: $body-light-gray-color;
+
+  @media (max-width: $phone-xlarge) {
+    background-color: white;
+  }
 
   &.white-bg {
     background-color: white;
@@ -24,7 +29,12 @@ $docs-content-border-radius: 3px;
       border-radius: $docs-content-border-radius;
       padding: $docs-content-padding;
       margin-bottom: $docs-content-margin-bottom;
-      min-width:0 // Fixes a bug when `pre` code breaks flex element
+      min-width: 0; // Fixes a bug when `pre` code breaks flex element
+
+      @media (max-width: $phone-xlarge) {
+        padding: $docs-content-padding-mobile;
+        border: none;
+      }
     }
   }
 

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,7 +1,7 @@
 ---
 title: Examples
 headline: 'Spine Examples'
-bodyclass: docs
+bodyclass: 'docs white-bg'
 layout: docs
 type: markdown
 ---

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 layout: docs
 title: Documentation
 headline: Documentation
-bodyclass: docs
+bodyclass: 'docs white-bg'
 ---
 
 <section class="intro-section">

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -8,9 +8,9 @@ bodyclass: 'docs white-bg'
 <section class="intro-section">
     <div class="container-fluid content-holder">
         <div class="row">
-            <div class="col-md-7">
-                <p>This section of Spine documentation contains links&nbsp; to the language-specific automatically generated
-                    API reference.</p>
+            <div class="col-md-5 mb-4">
+                <p>This section of Spine documentation contains links to the
+                    <nobr>language-specific</nobr> automatically generated API reference.</p>
             </div>
             <div class="lang-card-selector col-md-12 display-flex">
                 <div class="lang-card">

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -1,9 +1,8 @@
 ---
-bodyclass: docs
 title: Reference
 headline: 'Language-specific API Reference'
 layout: docs
-bodyclass: docs
+bodyclass: 'docs white-bg'
 ---
 
 <section class="intro-section">
@@ -13,7 +12,6 @@ bodyclass: docs
                 <p>This section of Spine documentation contains links&nbsp; to the language-specific automatically generated
                     API reference.</p>
             </div>
-
             <div class="lang-card-selector col-md-12 display-flex">
                 <div class="lang-card">
                     <header class="icon-java lang-card-title">Java</header>
@@ -22,14 +20,12 @@ bodyclass: docs
                         <li><a href="/core-java/javadoc/server/index.html">Server-side API</a></li>
                     </ul>
                 </div>
-
                 <div class="lang-card">
                     <header class="icon-javascript lang-card-title">JavaScript</header>
                     <ul class="lang-card-link">
                         <li><a href="javascript/index.html">JavaScript Client API</a></li>
                     </ul>
                 </div>
-
                 <div class="lang-card">
                     <header class="icon-cpp lang-card-title">C++</header>
                     <ul class="lang-card-link">

--- a/js/common.js
+++ b/js/common.js
@@ -36,6 +36,7 @@ $(function() {
     preventDefaultScroll();
     initTocTocify();
     showScrollTopBtn();
+    fixStickyElement();
 });
 
 jQuery(window).on('load', function() {

--- a/js/common.js
+++ b/js/common.js
@@ -158,24 +158,24 @@ function setStickyElMaxHeight() {
 /**
  * Calculates a sticky element heights to make sure that it always fits on the page.
  *
- * @return {{initialHeight: number, maxHeight: number}}
+ * @return {Object} an object with initial and calculated heights.
+ * {number} initialHeight initial element max-height when the scroll at the top
+ *          or at the middle of the page
+ * {number} maxHeight max height that dynamically changes on scroll at the bottom of the page
  */
 function calcStickyElHeight() {
     const windowHeight = $(window).height();
     const scrollPosition = $(window).scrollTop();
     const footerTopPoint = $('.footer').position().top;
     const cookieContainerHeight = $('#cookieChoiceInfo').innerHeight();
-
-    /** The distance from the element to the bottom of the window. */
-    const contentMarginBottom = 8;
-
-    /** Initial element max-height when the scroll at the top or middle of the page */
-    const initialHeight = windowHeight - stickyElementPosition - contentMarginBottom - cookieContainerHeight;
-
-    /** Dynamic value that changes on scroll. When the scroll at the bottom of the page,
-     * element height decreases.
+    /**
+     * The distance from the element to the footer top point.
+     * The value is the same as `docs-content-text` has.
      */
-    const maxHeight = footerTopPoint - scrollPosition - stickyElementPosition - contentMarginBottom;
+    const contentMarginBottom = 32;
+
+    const initialHeight = windowHeight - stickyElementPosition + contentMarginBottom - cookieContainerHeight;
+    const maxHeight = footerTopPoint - scrollPosition - stickyElementPosition + contentMarginBottom;
 
     return {initialHeight, maxHeight};
 }

--- a/js/common.js
+++ b/js/common.js
@@ -27,7 +27,6 @@ $.getScript("/libs/prettify/js/lang-yaml.js", function(){});
 
 const initialHeadHeight = $('#header').innerHeight();
 const tocNav = $('#toc');
-const sideNav = $('.docs-side-nav');
 const headerFixPosition = $('.nav-hero-container').innerHeight();
 const stickyElement = $('.sticky-element');
 const stickyElementPosition = headerFixPosition; // Sticky element top-offset (154px)
@@ -43,8 +42,7 @@ $(function() {
 jQuery(window).on('load', function() {
     scrollToAnchor();
     ifCookiesExist();
-    tocHeight();
-    setSideNavHeight();
+    setStickyElMaxHeight();
 });
 
 // Make functions works immediately on hash change
@@ -56,8 +54,7 @@ window.onhashchange = function() {
 window.onscroll = function() {
     fixStickyElement();
     fixHead();
-    tocHeight();
-    setSideNavHeight();
+    setStickyElMaxHeight();
     showScrollTopBtn();
 };
 
@@ -139,8 +136,11 @@ function fixHead() {
     }
 }
 
-function tocHeight() {
-    if (tocNav.length) {
+/**
+ * Sets max-height for the sticky element depends on the scroll position.
+ */
+function setStickyElMaxHeight() {
+    if (stickyElement.length) {
         const elHeights = calcStickyElHeight();
 
         /**
@@ -148,25 +148,9 @@ function tocHeight() {
          * position at the top of the page.
          */
         if (elHeights.maxHeight < elHeights.initialHeight) {
-            $(tocNav).css('max-height', elHeights.maxHeight);
+            $(stickyElement).css('max-height', elHeights.maxHeight);
         } else {
-            $(tocNav).css('max-height', elHeights.initialHeight);
-        }
-    }
-}
-
-function setSideNavHeight() {
-    if (sideNav.length) {
-        const elHeights = calcStickyElHeight();
-
-        /**
-         * Determines that the max-height value is less than browser window when the scroll
-         * position at the top of the page.
-         */
-        if (elHeights.maxHeight < elHeights.initialHeight) {
-            $(sideNav).css('max-height', elHeights.maxHeight);
-        } else {
-            $(sideNav).css('max-height', elHeights.initialHeight);
+            $(stickyElement).css('max-height', elHeights.initialHeight);
         }
     }
 }
@@ -199,7 +183,7 @@ function calcStickyElHeight() {
 // Resize TOC height when window height is changing
 function resizeTocHeightWithWindow() {
     if ($(window).height() > 600) {
-        tocHeight();
+        setStickyElMaxHeight();
     }
 }
 

--- a/js/common.js
+++ b/js/common.js
@@ -122,30 +122,43 @@ function fixHead() {
 
 function tocHeight() {
     if (tocNav.length) {
-        var windowHeight = $(window).height();
-        var scrollPosition = $(window).scrollTop();
-        var footerTopPoint = $(".footer").position().top;
-        var cookieContainerHeight = $("#cookieChoiceInfo").innerHeight();
-        var contentMarginBottom = 60; /* The distance from the TOC to the bottom of the window. The value the same
-        as a docs content. So the content and the TOC will be ended at the same line */
+        const elHeights = calcStickyElHeight();
 
-        /* Initial TOC max-height when the scroll at the top or middle of the page */
-        var initialTocHeight = windowHeight - stickyElementPosition - contentMarginBottom - cookieContainerHeight;
-
-        /* Dynamic value that changes on scroll. When the scroll at the bottom of the page, TOC height decreases. */
-        var maxHeightValue = footerTopPoint - scrollPosition - stickyElementPosition - contentMarginBottom;
-
-
-        /*The max-height value can be bigger than browser window if the scroll at the top of page.
-        * So here is added the check*/
-        if (maxHeightValue < initialTocHeight) {
-            $(tocNav).css('max-height', maxHeightValue);
-        }
-
-        else {
-            $(tocNav).css('max-height', initialTocHeight);
+        /**
+         * Determines that the max-height value is less than browser window when the scroll
+         * position at the top of the page.
+         */
+        if (elHeights.maxHeight < elHeights.initialHeight) {
+            $(tocNav).css('max-height', elHeights.maxHeight);
+        } else {
+            $(tocNav).css('max-height', elHeights.initialHeight);
         }
     }
+}
+
+/**
+ * Calculates a sticky element heights to make sure that it always fits on the page.
+ *
+ * @return {{initialHeight: number, maxHeight: number}}
+ */
+function calcStickyElHeight() {
+    const windowHeight = $(window).height();
+    const scrollPosition = $(window).scrollTop();
+    const footerTopPoint = $('.footer').position().top;
+    const cookieContainerHeight = $('#cookieChoiceInfo').innerHeight();
+
+    /** The distance from the element to the bottom of the window. */
+    const contentMarginBottom = 8;
+
+    /** Initial element max-height when the scroll at the top or middle of the page */
+    const initialHeight = windowHeight - stickyElementPosition - contentMarginBottom - cookieContainerHeight;
+
+    /** Dynamic value that changes on scroll. When the scroll at the bottom of the page,
+     * element height decreases.
+     */
+    const maxHeight = footerTopPoint - scrollPosition - stickyElementPosition - contentMarginBottom;
+
+    return {initialHeight, maxHeight};
 }
 
 // Resize TOC height when window height is changing

--- a/js/common.js
+++ b/js/common.js
@@ -29,7 +29,7 @@ const initialHeadHeight = $('#header').innerHeight();
 const tocNav = $('#toc');
 const headerFixPosition = $('.nav-hero-container').innerHeight();
 const stickyElement = $('.sticky-element');
-const stickyElementPosition = 140; // Sticky element top-offset
+const stickyElementPosition = headerFixPosition; // Sticky element top-offset (154px)
 
 $(function() {
     expandItemOnHashChange();

--- a/js/common.js
+++ b/js/common.js
@@ -30,6 +30,8 @@ const tocNav = $('#toc');
 const headerFixPosition = $('.nav-hero-container').innerHeight();
 const stickyElement = $('.sticky-element');
 const stickyElementPosition = headerFixPosition; // Sticky element top-offset (154px)
+const goTopBtn = $('#go-top-btn');
+const copyrightEl = $('.copyright');
 
 $(function() {
     expandItemOnHashChange();
@@ -45,7 +47,9 @@ jQuery(window).on('load', function() {
     setStickyElMaxHeight();
 });
 
-// Make functions works immediately on hash change
+/**
+ * Makes functions work immediately when the hash changes.
+ */
 window.onhashchange = function() {
     expandItemOnHashChange();
     scrollToAnchor();
@@ -99,7 +103,6 @@ function fixStickyElement() {
         }
     }
 }
-
 
 /**
  * Makes header navigation sticky on scroll.
@@ -180,54 +183,59 @@ function calcStickyElHeight() {
     return {initialHeight, maxHeight};
 }
 
-// Resize TOC height when window height is changing
+/**
+ * Changes the height of the `toc` when changing the height of the window.
+ */
 function resizeTocHeightWithWindow() {
     if ($(window).height() > 600) {
         setStickyElMaxHeight();
     }
 }
 
-// Expand FAQ item on hash change
+/**
+ * Expands FAQ item on hash change.
+ */
 function expandItemOnHashChange() {
-    if ("onhashchange" in window) {
+    if ('onhashchange' in window) {
         $(location.hash).collapse('show');
     }
 }
 
-// Prevent default scroll and double click on the same hash
+/**
+ * Prevents default scroll behavior and prevents double click on the same hash.
+ */
 function preventDefaultScroll() {
     $('.anchor-link').click(function(event) {
-        var anchor = $(this).attr("href");
-        var x = window.pageXOffset;
-        var y = window.pageYOffset;
+        const anchor = $(this).attr('href');
+        const x = window.pageXOffset;
+        const y = window.pageYOffset;
         event.preventDefault();
         window.location.hash = anchor;
         window.scrollTo(x, y);
     });
 }
 
+/**
+ * Scrolls to the anchor.
+ */
 function scrollToAnchor() {
-    var anchor = location.hash;
-    var offset = -150; // Top offset for move header below fixed header
+    const anchor = location.hash;
+    const offset = -150; // Top offset to move the header below the fixed header
 
     if ($(anchor).length) {
         $(window).scrollTo($(anchor), 500, {offset: offset});
     }
 }
 
-
-var goTopBtn = $("#go-top-btn");
-var copyrightEl = $(".copyright");
-
 /**
  * Adds additional padding values if the `cookieChoiceInfo` exist on the page.
  */
 function ifCookiesExist() {
-    var cookieInfo = $("#cookieChoiceInfo");
-    var cookieAgreeBtn = $("#cookieChoiceDismiss");
-    var cookieContainerHeight = cookieInfo.innerHeight();
-    var marginBottom = 10; // A bottom margin for the `Go to Top` button
-    var copyrightPaddingBottom = 24; // A bottom padding for the `Copyright` div element
+    const cookieInfo = $('#cookieChoiceInfo');
+    const cookieAgreeBtn = $('#cookieChoiceDismiss');
+    const cookieContainerHeight = cookieInfo.innerHeight();
+    const marginBottom = 10; // A bottom margin for the `Go to Top` button
+    const copyrightPaddingBottom = 24; // A bottom padding for the `Copyright` div element
 
     if(cookieInfo.length){
         $(goTopBtn).css('bottom', cookieContainerHeight + marginBottom);
@@ -240,15 +248,15 @@ function ifCookiesExist() {
             $(goTopBtn).css('bottom', marginBottom);
             $(copyrightEl).css('padding-bottom', copyrightPaddingBottom);
         });
-    }
-
-    else {
+    } else {
         $(goTopBtn).css('bottom', marginBottom);
         $(copyrightEl).css('padding-bottom', copyrightPaddingBottom);
     }
 }
 
-// When the user scrolls down 1500px from the top of the document, show the button ”Go to Top“
+/**
+ * Shows `Go to Top` button when the scroll position is 1500px.
+ */
 function showScrollTopBtn() {
     if ($(this).scrollTop() > 1500 ) {
         $(goTopBtn).show();
@@ -258,7 +266,10 @@ function showScrollTopBtn() {
     }
 }
 
-// When the user clicks on the button, scroll to the top of the document
+/**
+ * Scrolls to the top of the page.
+ */
 function topFunction() {
-    $("html, body").stop().animate({scrollTop: 0}, 500, 'swing'); return false;
+    $('html, body').stop().animate({scrollTop: 0}, 500, 'swing');
+    return false;
 }

--- a/js/common.js
+++ b/js/common.js
@@ -118,6 +118,9 @@ function fixStickyElement() {
 
 /**
  * Makes header navigation sticky on scroll.
+ *
+ * <p>The header will not be sticky if the `header` has `hide-sticky-header` class. But it
+ * still working on mobile devices. Used for all `docs` pages.
  */
 function fixHead() {
     const stickyHeaderHidden = header.hasClass('hide-sticky-header');

--- a/js/common.js
+++ b/js/common.js
@@ -60,6 +60,7 @@ window.onscroll = function() {
 $(window).resize(function() {
     resizeTocHeightWithWindow();
     ifCookiesExist();
+    fixHead();
 });
 
 /**
@@ -100,12 +101,19 @@ function fixStickyElement() {
 
 
 /**
- * Fix header navigation on scroll.
+ * Makes header navigation sticky on scroll.
  */
 function fixHead() {
     const header = $('#header');
+    const stickyHeaderHidden = header.hasClass('hide-sticky-header');
+    const mobileSize = 640;
+    const mobileWindow = $(window).width() <= mobileSize;
+    const desktopWindow = $(window).width() > mobileSize;
+    const headerExistAndNotHidden = header.length && !stickyHeaderHidden;
+    const headerOnMobile = header.length && mobileWindow;
+    const headerHiddedAndNotMobile = header.length && stickyHeaderHidden && desktopWindow;
 
-    if (header.length && !(header).hasClass('hide-sticky-header')) {
+    if (headerExistAndNotHidden || headerOnMobile) {
         if (window.pageYOffset > headerFixPosition) {
             header.addClass('not-top'); // When the navigation below offset
             header.addClass('pinned'); // When the navigation below hero section
@@ -119,6 +127,11 @@ function fixHead() {
             header.removeClass('not-top');
             header.removeClass('unpinned');
         }
+    }
+
+    if (headerHiddedAndNotMobile) {
+        header.removeClass('not-top');
+        header.removeClass('unpinned');
     }
 }
 

--- a/js/common.js
+++ b/js/common.js
@@ -68,17 +68,18 @@ $(window).resize(function() {
  * @see {@link http://gregfranko.com/jquery.tocify.js/ Toc Tocify}
  */
 function initTocTocify() {
-    const docsContainer = $(".docs-content");
-    const headersQuantity = docsContainer.find("h2, h3, h4");
+    const docsContainer = $('.docs-content-text');
+    const headersQuantity = docsContainer.find('h2, h3, h4');
     const topOffset = 12; // Offset from the `header` navigation
 
     if (headersQuantity.length >= 3) {
         tocNav.tocify({
-            selectors: "h2, h3, h4",
+            context: docsContainer,
+            selectors: 'h2, h3, h4',
             showAndHide: false,
             scrollTo: initialHeadHeight + topOffset,
             extendPage: false,
-            hashGenerator: "Pretty"
+            hashGenerator: 'Pretty'
         });
     }
 }

--- a/js/common.js
+++ b/js/common.js
@@ -25,11 +25,11 @@ $.getScript("/libs/prettify/js/lang-swift.js", function(){});
 $.getScript("/libs/prettify/js/lang-yaml.js", function(){});
 
 
-var initialHeadHeight = $("#header").innerHeight();
-var tocNav = $('#toc');
-var headerFixPosition = $(".nav-hero-container").innerHeight();
+const initialHeadHeight = $('#header').innerHeight();
+const tocNav = $('#toc');
+const headerFixPosition = $('.nav-hero-container').innerHeight();
 const stickyElement = $('.sticky-element');
-const stickyNavPosition = 120; // Sticky element top-offset
+const stickyElementPosition = 120; // Sticky element top-offset
 
 $(function() {
     expandItemOnHashChange();
@@ -87,7 +87,7 @@ function initTocTocify() {
  */
 function fixStickyElement() {
     if (stickyElement.length) {
-        if (window.pageYOffset > stickyNavPosition) {
+        if (window.pageYOffset > stickyElementPosition) {
             stickyElement.addClass('sticky');
         }
         else {
@@ -128,10 +128,10 @@ function tocHeight() {
         as a docs content. So the content and the TOC will be ended at the same line */
 
         /* Initial TOC max-height when the scroll at the top or middle of the page */
-        var initialTocHeight = windowHeight - stickyNavPosition - contentMarginBottom - cookieContainerHeight;
+        var initialTocHeight = windowHeight - stickyElementPosition - contentMarginBottom - cookieContainerHeight;
 
         /* Dynamic value that changes on scroll. When the scroll at the bottom of the page, TOC height decreases. */
-        var maxHeightValue = footerTopPoint - scrollPosition - stickyNavPosition - contentMarginBottom;
+        var maxHeightValue = footerTopPoint - scrollPosition - stickyElementPosition - contentMarginBottom;
 
 
         /*The max-height value can be bigger than browser window if the scroll at the top of page.

--- a/js/common.js
+++ b/js/common.js
@@ -1,29 +1,4 @@
-// Mobile navigation toggle
-$('#nav-icon-menu').click(function(){
-    $(this).toggleClass('open');
-    $('body').toggleClass('navigation-opened');
-});
-
-
-// Add the 'external' class to every outbound link on the site.
-// The css will add a small right arrow after the link.
-$('a').filter(function() {
-   return this.hostname && this.hostname !== location.hostname;
-}).addClass("external");
-
-// Remove external mark on Octocat icons, that already look external enough.
-$("i.fa-github-alt").parent().removeClass("external");
-
-
-// Prettyprint
-$('pre').addClass("prettyprint");
-$.getScript("/libs/prettify/js/run_prettify.js", function(){});
-$.getScript("/libs/prettify/js/lang-css.js", function(){});
-$.getScript("/libs/prettify/js/lang-go.js", function(){});
-$.getScript("/libs/prettify/js/lang-proto.js", function(){});
-$.getScript("/libs/prettify/js/lang-swift.js", function(){});
-$.getScript("/libs/prettify/js/lang-yaml.js", function(){});
-
+'use strict';
 
 const initialHeadHeight = $('#header').innerHeight();
 const tocNav = $('#toc');
@@ -34,6 +9,9 @@ const goTopBtn = $('#go-top-btn');
 const copyrightEl = $('.copyright');
 
 $(function() {
+    initPrettyprint();
+    openHeaderMenuOnMobile();
+    addExternalClass();
     expandItemOnHashChange();
     preventDefaultScroll();
     initTocTocify();
@@ -47,9 +25,6 @@ jQuery(window).on('load', function() {
     setStickyElMaxHeight();
 });
 
-/**
- * Makes functions work immediately when the hash changes.
- */
 window.onhashchange = function() {
     expandItemOnHashChange();
     scrollToAnchor();
@@ -63,10 +38,46 @@ window.onscroll = function() {
 };
 
 $(window).resize(function() {
-    resizeTocHeightWithWindow();
+    resizeStickyElHeightWithWindow();
     ifCookiesExist();
     fixHead();
 });
+
+/**
+ * Inits pretty-print scripts.
+ *
+ * @see {@link https://github.com/google/code-prettify/blob/master/docs/getting_started.md code-prettify}
+ */
+function initPrettyprint() {
+    $('pre').addClass('prettyprint');
+    $.getScript("/libs/prettify/js/run_prettify.js", function(){});
+    $.getScript("/libs/prettify/js/lang-css.js", function(){});
+    $.getScript("/libs/prettify/js/lang-go.js", function(){});
+    $.getScript("/libs/prettify/js/lang-proto.js", function(){});
+    $.getScript("/libs/prettify/js/lang-swift.js", function(){});
+    $.getScript("/libs/prettify/js/lang-yaml.js", function(){});
+}
+
+/**
+ * Opens header menu on mobile device.
+ */
+function openHeaderMenuOnMobile() {
+    $('#nav-icon-menu').click(function(){
+        $(this).toggleClass('open');
+        $('body').toggleClass('navigation-opened');
+    });
+}
+
+/**
+ * Adds the `external` class to every outbound link on the site.
+ *
+ * <p>The css will add a small right arrow after the link.
+ */
+function addExternalClass() {
+    $('a').filter(function() {
+        return this.hostname && this.hostname !== location.hostname;
+    }).addClass('external');
+}
 
 /**
  * Inits `toc` navigation if a page has more than 2 headers.
@@ -184,9 +195,9 @@ function calcStickyElHeight() {
 }
 
 /**
- * Changes the height of the `toc` when changing the height of the window.
+ * Changes the height of the `.sticky-element` when changing the height of the window.
  */
-function resizeTocHeightWithWindow() {
+function resizeStickyElHeightWithWindow() {
     if ($(window).height() > 600) {
         setStickyElMaxHeight();
     }

--- a/js/common.js
+++ b/js/common.js
@@ -77,7 +77,8 @@ function initTocTocify() {
             selectors: "h2, h3, h4",
             showAndHide: false,
             scrollTo: initialHeadHeight + topOffset,
-            extendPage: false
+            extendPage: false,
+            hashGenerator: "Pretty"
         });
     }
 }

--- a/js/common.js
+++ b/js/common.js
@@ -98,24 +98,26 @@ function fixStickyElement() {
     }
 }
 
-// Animation header on scroll
-function fixHead() {
-    var header = $('#header');
-    if (header.length) {
-        if (window.pageYOffset > headerFixPosition) {
-            header.addClass("not-top"); // When navigation below offset
-            header.addClass("pinned"); // When navigation below hero section
-            header.removeClass("unpinned");
-        }
-        else {
-            header.removeClass("pinned");
-            header.addClass("unpinned");
-        }
 
-        // Return classes to the initial state when the navigation at the top of the page
+/**
+ * Fix header navigation on scroll.
+ */
+function fixHead() {
+    const header = $('#header');
+
+    if (header.length && !(header).hasClass('hide-sticky-header')) {
+        if (window.pageYOffset > headerFixPosition) {
+            header.addClass('not-top'); // When the navigation below offset
+            header.addClass('pinned'); // When the navigation below hero section
+            header.removeClass('unpinned');
+        } else {
+            header.removeClass('pinned');
+            header.addClass('unpinned');
+        }
+        /** Returns classes to the initial state when the navigation at the top of the page. */
         if (window.pageYOffset < initialHeadHeight) {
-            header.removeClass("not-top");
-            header.removeClass("unpinned");
+            header.removeClass('not-top');
+            header.removeClass('unpinned');
         }
     }
 }

--- a/js/common.js
+++ b/js/common.js
@@ -97,7 +97,7 @@ function initTocTocify() {
             showAndHide: false,
             scrollTo: initialHeadHeight + topOffset,
             extendPage: false,
-            hashGenerator: 'Pretty'
+            hashGenerator: 'pretty'
         });
     }
 }

--- a/js/common.js
+++ b/js/common.js
@@ -27,6 +27,7 @@ $.getScript("/libs/prettify/js/lang-yaml.js", function(){});
 
 const initialHeadHeight = $('#header').innerHeight();
 const tocNav = $('#toc');
+const sideNav = $('.docs-side-nav');
 const headerFixPosition = $('.nav-hero-container').innerHeight();
 const stickyElement = $('.sticky-element');
 const stickyElementPosition = headerFixPosition; // Sticky element top-offset (154px)
@@ -43,6 +44,7 @@ jQuery(window).on('load', function() {
     scrollToAnchor();
     ifCookiesExist();
     tocHeight();
+    setSideNavHeight();
 });
 
 // Make functions works immediately on hash change
@@ -55,6 +57,7 @@ window.onscroll = function() {
     fixStickyElement();
     fixHead();
     tocHeight();
+    setSideNavHeight();
     showScrollTopBtn();
 };
 
@@ -148,6 +151,22 @@ function tocHeight() {
             $(tocNav).css('max-height', elHeights.maxHeight);
         } else {
             $(tocNav).css('max-height', elHeights.initialHeight);
+        }
+    }
+}
+
+function setSideNavHeight() {
+    if (sideNav.length) {
+        const elHeights = calcStickyElHeight();
+
+        /**
+         * Determines that the max-height value is less than browser window when the scroll
+         * position at the top of the page.
+         */
+        if (elHeights.maxHeight < elHeights.initialHeight) {
+            $(sideNav).css('max-height', elHeights.maxHeight);
+        } else {
+            $(sideNav).css('max-height', elHeights.initialHeight);
         }
     }
 }

--- a/js/common.js
+++ b/js/common.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const initialHeadHeight = $('#header').innerHeight();
+const header = $('#header');
+const initialHeadHeight = header.innerHeight();
 const tocNav = $('#toc');
 const headerFixPosition = $('.nav-hero-container').innerHeight();
 const stickyElement = $('.sticky-element');
@@ -119,7 +120,6 @@ function fixStickyElement() {
  * Makes header navigation sticky on scroll.
  */
 function fixHead() {
-    const header = $('#header');
     const stickyHeaderHidden = header.hasClass('hide-sticky-header');
     const mobileSize = 640;
     const mobileWindow = $(window).width() <= mobileSize;
@@ -137,17 +137,23 @@ function fixHead() {
             header.removeClass('pinned');
             header.addClass('unpinned');
         }
-        /** Returns classes to the initial state when the navigation at the top of the page. */
+        /** Determines the header at the top of the page. */
         if (window.pageYOffset < initialHeadHeight) {
-            header.removeClass('not-top');
-            header.removeClass('unpinned');
+            returnToInitialState();
         }
     }
 
     if (headerHiddedAndNotMobile) {
-        header.removeClass('not-top');
-        header.removeClass('unpinned');
+        returnToInitialState();
     }
+}
+
+/**
+ * Returns header classes to the initial state.
+ */
+function returnToInitialState() {
+    header.removeClass('not-top');
+    header.removeClass('unpinned');
 }
 
 /**

--- a/js/common.js
+++ b/js/common.js
@@ -28,8 +28,8 @@ $.getScript("/libs/prettify/js/lang-yaml.js", function(){});
 var initialHeadHeight = $("#header").innerHeight();
 var tocNav = $('#toc');
 var headerFixPosition = $(".nav-hero-container").innerHeight();
-var tocNavFixedPosition = 120; // Sticky TOC offset
-
+const stickyElement = $('.sticky-element');
+const stickyNavPosition = 120; // Sticky element top-offset
 
 $(function() {
     expandItemOnHashChange();
@@ -51,7 +51,7 @@ window.onhashchange = function() {
 };
 
 window.onscroll = function() {
-    fixToc();
+    fixStickyElement();
     fixHead();
     tocHeight();
     showScrollTopBtn();
@@ -82,14 +82,16 @@ function initTocTocify() {
     }
 }
 
-// Fix TOC navigation on page while scrolling
-function fixToc() {
-    if (tocNav.length) {
-        if (window.pageYOffset > tocNavFixedPosition) {
-            tocNav.addClass("sticky");
+/**
+ * Fix sticky element on page while scrolling.
+ */
+function fixStickyElement() {
+    if (stickyElement.length) {
+        if (window.pageYOffset > stickyNavPosition) {
+            stickyElement.addClass('sticky');
         }
         else {
-            tocNav.removeClass("sticky");
+            stickyElement.removeClass('sticky');
         }
     }
 }
@@ -126,10 +128,10 @@ function tocHeight() {
         as a docs content. So the content and the TOC will be ended at the same line */
 
         /* Initial TOC max-height when the scroll at the top or middle of the page */
-        var initialTocHeight = windowHeight - tocNavFixedPosition - contentMarginBottom - cookieContainerHeight;
+        var initialTocHeight = windowHeight - stickyNavPosition - contentMarginBottom - cookieContainerHeight;
 
         /* Dynamic value that changes on scroll. When the scroll at the bottom of the page, TOC height decreases. */
-        var maxHeightValue = footerTopPoint - scrollPosition - tocNavFixedPosition - contentMarginBottom;
+        var maxHeightValue = footerTopPoint - scrollPosition - stickyNavPosition - contentMarginBottom;
 
 
         /*The max-height value can be bigger than browser window if the scroll at the top of page.

--- a/js/common.js
+++ b/js/common.js
@@ -29,7 +29,7 @@ const initialHeadHeight = $('#header').innerHeight();
 const tocNav = $('#toc');
 const headerFixPosition = $('.nav-hero-container').innerHeight();
 const stickyElement = $('.sticky-element');
-const stickyElementPosition = 120; // Sticky element top-offset
+const stickyElementPosition = 140; // Sticky element top-offset
 
 $(function() {
     expandItemOnHashChange();

--- a/js/os-licenses.js
+++ b/js/os-licenses.js
@@ -3,34 +3,35 @@
  *
  * Please see `/os-licenses/index.html` for usage.
  */
+'use strict';
 
 $(
     function() {
-        var converter = new showdown.Converter();
-        const loadedAttr = "loaded";
-        const repoAttr = "repo";
-        const repoName = "repo-name";
+        const converter = new showdown.Converter();
+        const loadedAttr = 'loaded';
+        const repoAttr = 'repo';
+        const repoName = 'repo-name';
 
         /**
          * Loads `license-report` file from the repository.
          *
-         * <p>Executes by clicking on the corresponding link. The destination `div` element should have
-         * the `id` like `md-destination-REPO_NAME`.
+         * <p>Executes by clicking on the corresponding link. The destination `div` element
+         * should have the `id` like `md-destination-REPO_NAME`.
          */
-        $(".collapsible-panel-title").click(function () {
-            var clickedElement = $(this);
-            var clickedElRepoName = clickedElement.attr(repoName);
-            var mdDestinationEl = $("#md-destination-" + clickedElRepoName);
-            var loaded = clickedElement.attr(loadedAttr);
+        $('.collapsible-panel-title').click(function () {
+            const clickedElement = $(this);
+            const clickedElRepoName = clickedElement.attr(repoName);
+            const mdDestinationEl = $('#md-destination-' + clickedElRepoName);
+            const loaded = clickedElement.attr(loadedAttr);
 
-            if (loaded === "false") {
-                var repositoryUrl = clickedElement.attr(repoAttr);
+            if (loaded === 'false') {
+                const repositoryUrl = clickedElement.attr(repoAttr);
                 $.get(
-                    repositoryUrl + "/master/license-report.md",
+                    repositoryUrl + '/master/license-report.md',
                     function (data) {
-                        var html = converter.makeHtml(data);
+                        const html = converter.makeHtml(data);
                         mdDestinationEl.html(html);
-                        clickedElement.attr(loadedAttr, "true");
+                        clickedElement.attr(loadedAttr, 'true');
                         makeCollapsibleTitle(mdDestinationEl, clickedElRepoName);
                     }
                 );
@@ -40,21 +41,21 @@ $(
         /**
          * Makes a `license-report` content collapsible.
          *
-         * @param mdDestinationEl it is a `div` with a markdown content
-         * @param clickedElRepoName a repository name from the link attribute
+         * @param mdDestinationEl `div` with the markdown content
+         * @param clickedElRepoName repository name from the link attribute
          */
         function makeCollapsibleTitle(mdDestinationEl, clickedElRepoName) {
-            var h1Elements = mdDestinationEl.find("h1");
-            var h2Elements = mdDestinationEl.find("h2");
-            var linkElements = mdDestinationEl.find("a");
+            const h1Elements = mdDestinationEl.find('h1');
+            const h2Elements = mdDestinationEl.find('h2');
+            const linkElements = mdDestinationEl.find('a');
 
-            h1Elements.addClass("dependencies-title");
+            h1Elements.addClass('dependencies-title');
 
             /**
              * Removes `Dependencies of` words from the title.
              */
             h1Elements.each(function() {
-                var text = $(this).text();
+                const text = $(this).text();
                 $(this).text(text.replace('Dependencies of', ''));
             });
 
@@ -62,34 +63,34 @@ $(
              * Removes `dependencies:` from the titles inside the Spine Web repository.
              */
             h2Elements.each(function () {
-               var text = $(this).text();
+               const text = $(this).text();
                 $(this).text(text.replace('dependencies:', ''));
             });
 
             /**
              * Makes all markdown links external.
              */
-            linkElements.addClass("external");
-            linkElements.attr("target", "_blank");
+            linkElements.addClass('external');
+            linkElements.attr('target', '_blank');
 
             /**
              * Adds required classes and attributes to make titles and content collapsible.
              */
             h2Elements.each(function(index, element) {
                 // `-md` makes the destination ID different from the collapsible title ID
-                const titleID =  clickedElRepoName + "-" + this.id + "-md";
-                const collapsibleContent = $(element).next("ol");
-                const reportInfoContent = collapsibleContent.next("p");
+                const titleID =  clickedElRepoName + '-' + this.id + '-md';
+                const collapsibleContent = $(element).next('ol');
+                const reportInfoContent = collapsibleContent.next('p');
 
-                $(element).addClass("collapse-link collapsed");
-                $(element).attr("href", "#" + titleID);
-                $(element).attr("data-toggle", "collapse");
+                $(element).addClass('collapse-link collapsed');
+                $(element).attr('href', '#' + titleID);
+                $(element).attr('data-toggle', 'collapse');
 
-                collapsibleContent.addClass("dependencies-container collapse");
-                collapsibleContent.attr("id", titleID);
+                collapsibleContent.addClass('dependencies-container collapse');
+                collapsibleContent.attr('id', titleID);
 
-                reportInfoContent.addClass("report-info collapse");
-                reportInfoContent.attr("id", titleID + "-p");
+                reportInfoContent.addClass('report-info collapse');
+                reportInfoContent.attr('id', titleID + '-p');
             });
 
             makeReportInfoCollapsible(mdDestinationEl);
@@ -103,20 +104,20 @@ $(
          * @param mdDestinationEl it is a `div` with a markdown content
          */
         function makeReportInfoCollapsible(mdDestinationEl) {
-            var reportInfoContent = mdDestinationEl.find(".report-info");
+            const reportInfoContent = mdDestinationEl.find('.report-info');
 
             /**
              * Inserts a new collapsible title for the paragraph with a report information.
              */
-            var reportInfoTitleEl = "<h2 class='report-info-title collapse-link collapsed'>Report info</h2>";
+            const reportInfoTitleEl = "<h2 class='report-info-title collapse-link collapsed'>Report info</h2>";
             $(reportInfoTitleEl).insertBefore(reportInfoContent);
 
             reportInfoContent.each(function (index, element) {
                 const reportInfoID = this.id;
-                const reportInfoTitle = $(element).prev(".report-info-title");
+                const reportInfoTitle = $(element).prev('.report-info-title');
 
-                reportInfoTitle.attr("href", "#" + reportInfoID);
-                reportInfoTitle.attr("data-toggle", "collapse");
+                reportInfoTitle.attr('href', '#' + reportInfoID);
+                reportInfoTitle.attr('data-toggle', 'collapse');
             });
         }
     }

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -3,7 +3,7 @@ title: Privacy Statements
 headline: 'Privacy Statements'
 layout: privacy
 bodyclass: privacy-statements
-header-type: fixed-dark-header
+header_type: fixed-dark-header
 ---
 
 <section class="privacy-section">


### PR DESCRIPTION
This PR closes #217, #205.

In this PR I have recreated the document page layout and make it according to the design:

![image](https://user-images.githubusercontent.com/22611365/64013621-e5708e00-cb28-11e9-8f5f-f8d2dd2c2998.png)


Also, I have fixed several bugs:
- TOC had a duplicated menu item at the top;
- `doc-side-nav-mobile-toggle` was visible at 768px but the column hadn't had hidden yet;
- the `body-class` in the `base.html` had the wrong definition.

As part of the PR, I have also made sticky TOC functionality universal to use it for the `side-doc-nav`. And also, I have cleaned up the `common.js` file.