### PR TITLE
Remove duplicated `onload="PR.prettyPrint()"`

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -69,7 +69,7 @@
 
 </head>
 
-<body class="{{ page.bodyclass }}" onload="PR.prettyPrint()">
+<body class="{{ page.bodyclass }}">
   <div class="wrapper">
     <div class="main">
       {{ content }}


### PR DESCRIPTION
Remove the `onload` event, because it causes an error if ` common.js` hasn't loaded yet.
The function will be called inside the script.