### PR TITLE
Fix `nokogiri` module vulnerability issue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,10 +24,12 @@ GEM
     ethon (0.12.0)
       ffi (>= 1.3.0)
     eventmachine (1.2.7)
+    eventmachine (1.2.7-x64-mingw32)
     execjs (2.7.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     ffi (1.10.0)
+    ffi (1.10.0-x64-mingw32)
     forwardable-extended (2.6.0)
     gemoji (3.0.0)
     github-pages (193)
@@ -72,7 +74,7 @@ GEM
       listen (= 3.1.5)
       mercenary (~> 0.3)
       minima (= 2.5.0)
-      nokogiri (>= 1.8.2, < 2.0)
+      nokogiri (>= 1.10.1, < 2.0)
       rouge (= 2.2.1)
       terminal-table (~> 1.4)
     github-pages-health-check (1.8.1)
@@ -83,7 +85,7 @@ GEM
       typhoeus (~> 1.3)
     html-pipeline (2.10.0)
       activesupport (>= 2)
-      nokogiri (>= 1.4)
+      nokogiri (>= 1.10.1)
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
@@ -207,6 +209,8 @@ GEM
     multipart-post (2.0.0)
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
+    nokogiri (1.10.1-x64-mingw32)
+      mini_portile2 (~> 2.4.0)
     octokit (4.13.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     pathutil (0.16.2)
@@ -240,10 +244,11 @@ GEM
 
 PLATFORMS
   ruby
+  x64-mingw32
 
 DEPENDENCIES
   github-pages
   jekyll-paginate
 
 BUNDLED WITH
-   2.0.1
+   2.0.2


### PR DESCRIPTION
The  `nokogiri` module version was updated in this PR.  This is the Git Hub suggestion to avoid this module vulnerability.  