### PR TITLE
Fix `Toc` hash generation

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -287,8 +287,12 @@ function initTocTocify() {
             showAndHide: false,
             scrollTo: scrollToOffset,
             extendPage: false,
-            hashGenerator: 'pretty',
-            smoothScroll: false
+            smoothScroll: false,
+            hashGenerator: function(text, element) {
+                let hashValue = text.replace(/\s+/g, '-').toLowerCase();
+                hashValue = hashValue.replace(/[.,\/#!$%\^&\*;:{}=\_`~()]/g,"");
+                return hashValue;
+            }
         });
     }
 }


### PR DESCRIPTION
This PR brings a custom hash generation function that removes all punctuation symbols from the hash.

It fixes a bug when the generated hash has some punctuation symbol and it doesn't match with the title id. For example `improved-areas:` in the hash and `improved-areas` in the title.