### PR TITLE
Simplify the document side navigation

### DIFF
--- a/_data/navigation/README.md
+++ b/_data/navigation/README.md
@@ -49,7 +49,7 @@ tree by clicking on it.
 #### Example for the three-level navigation list
 
 ```
-concepts:
+doc_side_nav:
   - page: Messaging
     children:
       - page: Event

--- a/_data/navigation/README.md
+++ b/_data/navigation/README.md
@@ -1,6 +1,6 @@
 `doc-side-nav.yml` it is a YAML file with the navigation structure for all docs pages.
-Note that the YAML file should be located in the `_data` folder. Also, note that the suggested syntax for YAML files 
-is to use 2 spaces for indentation.
+Note that the YAML file should be located in the `_data` folder. Also, note that the suggested 
+syntax for YAML files is to use 2 spaces for indentation.
 
 Related files:
 - a liquid navigation template - `_includes/doc-side-nav.html`;
@@ -14,7 +14,7 @@ Now the navigation supports 3 levels of nesting.
 #### Example for the one-level navigation list
 
 ```
-concepts:
+doc_side_nav:
   - page: Command
     url: /docs/concepts/command.html
   - page: Event
@@ -22,8 +22,7 @@ concepts:
 ```
 
 Where:
-- `concepts` — navigation list name. The same name should be added for each `.md` file (that is in this list) as:
-`sidenav_list: concepts`.
+- `doc_side_nav` — navigation list name that is used in the navigation template.
 - `page` - the page name that will be displayed in the navigation.
 - `url` - the full path to the file. It depends on what folder the file is in.
 
@@ -31,21 +30,22 @@ Where:
 #### Example for the two-level navigation list
 
 ```
-concepts:
+doc_side_nav:
   - page: Messaging
     url: '#messaging'
-    sub_nav_id: messaging
-    sub_nav:
+    id: messaging
+    children:
       - page: Command
         url: /docs/concepts/command.html
       - page: Event
         url: /docs/concepts/event.html
 ```
 
-- `page` - the page name that will be displayed in the navigation and will show a collapsed tree by clicking on it.
-- `url` - href attribute that is equal to the collapsed sub-navigation `ID`.
-- `sub_nav_id` - `ID` of the collapsed sub-navigation.
-- `sub_nav` - sub-navigation container. It's always `sub_nav` for the second-level.
+- `page` - the page name that will be displayed in the navigation and will show a collapsed 
+tree by clicking on it.
+- `url` - href attribute that is equal to the collapsed child navigation `ID`.
+- `id` - `ID` of the collapsed child navigation.
+- `children` - children navigation container.
 
 #### Example for the three-level navigation list
 
@@ -53,16 +53,12 @@ concepts:
 concepts:
   - page: Messaging
     url: '#messaging'
-    sub_nav_id: messaging
-    sub_nav:
+    id: messaging
+    children:
       - page: Event
         url: '#sub-messaging'
-        sub_sub_nav_id: sub-messaging
-        sub_sub_nav:
-          page: New page on the 3rd level
-          url: /docs/conceps/3rd-level-file.html
+        id: sub-messaging
+        children:
+          - page: New page on the 3rd level
+            url: /docs/conceps/3rd-level-file.html
 ```
-
-To declare the third-level navigation use:
-- `sub_sub_nav_id` - `ID` of the collapsed third-level navigation list.
-- `sub_sub_nav` - third-level navigation container. It's always `sub_sub_nav` for the third-level.

--- a/_data/navigation/README.md
+++ b/_data/navigation/README.md
@@ -22,7 +22,7 @@ doc_side_nav:
 ```
 
 Where:
-- `doc_side_nav` — navigation list name that is used in the navigation template.
+- `doc_side_nav` — navigation list name that is used in the navigation template `_includes/doc-side-nav.html`.
 - `page` - the page name that will be displayed in the navigation.
 - `url` - the full path to the file. It depends on what folder the file is in.
 
@@ -32,8 +32,6 @@ Where:
 ```
 doc_side_nav:
   - page: Messaging
-    url: '#messaging'
-    id: messaging
     children:
       - page: Command
         url: /docs/concepts/command.html
@@ -43,21 +41,18 @@ doc_side_nav:
 
 - `page` - the page name that will be displayed in the navigation and will show a collapsed 
 tree by clicking on it.
-- `url` - href attribute that is equal to the collapsed child navigation `ID`.
-- `id` - `ID` of the collapsed child navigation.
-- `children` - children navigation container.
+- `children` - children navigation container with nesting pages.
+
+>It’s important not to have the same name for the navigation item in the same nesting level.
+>Because now the navigation item ID is generated automatically.
 
 #### Example for the three-level navigation list
 
 ```
 concepts:
   - page: Messaging
-    url: '#messaging'
-    id: messaging
     children:
       - page: Event
-        url: '#sub-messaging'
-        id: sub-messaging
         children:
           - page: New page on the 3rd level
             url: /docs/conceps/3rd-level-file.html

--- a/_data/navigation/doc_side_nav.yml
+++ b/_data/navigation/doc_side_nav.yml
@@ -1,22 +1,22 @@
 doc_side_nav:
   - page: Introduction
     url: '#introduction'
-    sub_nav_id: introduction
-    sub_nav:
+    id: introduction
+    children:
       - page: Project Structure
         url: /docs/introduction/project-structure.html
       - page: Naming Conventions
         url: /docs/introduction/naming-conventions.html
   - page: Concepts
     url: '#concepts'
-    sub_nav_id: concepts
-    sub_nav:
+    id: concepts
+    children:
       - page: Architecture Overview
         url: /docs/concepts/
       - page: Messaging
         url: '#messaging'
-        sub_sub_nav_id: messaging
-        sub_sub_nav:
+        id: messaging
+        children:
           - page: Command
             url: /docs/concepts/command.html
           - page: Event
@@ -31,8 +31,8 @@ doc_side_nav:
             url: /docs/concepts/event-reactor.html
       - page: Entities
         url: '#entities'
-        sub_sub_nav_id: entities
-        sub_sub_nav:
+        id: entities
+        children:
           - page: Identifier
             url: /docs/concepts/identifier.html
           - page: Aggregate
@@ -47,8 +47,8 @@ doc_side_nav:
             url: /docs/concepts/snapshot.html
       - page: Architecture
         url: '#architecture'
-        sub_sub_nav_id: architecture
-        sub_sub_nav:
+        id: architecture
+        children:
           - page: Bounded Context
             url: /docs/concepts/bounded-context.html
           - page: Command Bus
@@ -73,14 +73,14 @@ doc_side_nav:
             url: /docs/concepts/subscription-service.html
   - page: Quick Start
     url: '#quick-start'
-    sub_nav_id: quick-start
-    sub_nav:
+    id: quick-start
+    children:
       - page: Java
         url: /docs/quickstart/java.html
   - page: Guides
     url: '#guides'
-    sub_nav_id: guides
-    sub_nav:
+    id: guides
+    children:
       - page: Model Definition
         url: /docs/guides/model-definition.html
       - page: Validation User Guide
@@ -91,22 +91,22 @@ doc_side_nav:
         url: /docs/guides/defining-aggregate.html
       - page: Related Guides
         url: '#related-guides'
-        sub_sub_nav_id: related-guides
-        sub_sub_nav:
+        id: related-guides
+        children:
           - page: Protocol Buffers
             url: https://developers.google.com/protocol-buffers/docs/overview
           - page: gRPC
             url: https://grpc.io/docs/guides/index.html
   - page: Tutorials
     url: '#tutorials'
-    sub_nav_id: tutorials
-    sub_nav:
+    id: tutorials
+    children:
       - page: Overview
         url: /docs/tutorials/
       - page: Basic
         url: '#basic-tutorials'
-        sub_sub_nav_id: basic-tutorials
-        sub_sub_nav:
+        id: basic-tutorials
+        children:
           - page: Java
             url: /docs/tutorials/basic/java.html
           - page: JavaScript
@@ -115,24 +115,24 @@ doc_side_nav:
             url: /docs/tutorials/basic/cpp.html
   - page: Client Libraries
     url: '#client-libs'
-    sub_nav_id: client-libs
-    sub_nav:
+    id: client-libs
+    children:
       - page: Java
         url: '#lib-java'
-        sub_sub_nav_id: lib-java
-        sub_sub_nav:
+        id: lib-java
+        children:
           - page: API Reference
             url: https://spine.io/core-java/javadoc/client/index.html
       - page: JavaScript
         url: '#lib-js'
-        sub_sub_nav_id: lib-js
-        sub_sub_nav:
+        id: lib-js
+        children:
           - page: API Reference
             url: https://spine.io/docs/reference/javascript/index.html
       - page: Dart
         url: '#lib-dart'
-        sub_sub_nav_id: lib-dart
-        sub_sub_nav:
+        id: lib-dart
+        children:
           - page: API Reference
             url: https://spine.io/docs/reference/dart/index.html
   - page: Examples

--- a/_data/navigation/doc_side_nav.yml
+++ b/_data/navigation/doc_side_nav.yml
@@ -1,21 +1,15 @@
 doc_side_nav:
   - page: Introduction
-    url: '#introduction'
-    id: introduction
     children:
       - page: Project Structure
         url: /docs/introduction/project-structure.html
       - page: Naming Conventions
         url: /docs/introduction/naming-conventions.html
   - page: Concepts
-    url: '#concepts'
-    id: concepts
     children:
       - page: Architecture Overview
         url: /docs/concepts/
       - page: Messaging
-        url: '#messaging'
-        id: messaging
         children:
           - page: Command
             url: /docs/concepts/command.html
@@ -30,8 +24,6 @@ doc_side_nav:
           - page: Event Reactor
             url: /docs/concepts/event-reactor.html
       - page: Entities
-        url: '#entities'
-        id: entities
         children:
           - page: Identifier
             url: /docs/concepts/identifier.html
@@ -46,8 +38,6 @@ doc_side_nav:
           - page: Snapshot
             url: /docs/concepts/snapshot.html
       - page: Architecture
-        url: '#architecture'
-        id: architecture
         children:
           - page: Bounded Context
             url: /docs/concepts/bounded-context.html
@@ -72,14 +62,10 @@ doc_side_nav:
           - page: Subscription Service
             url: /docs/concepts/subscription-service.html
   - page: Quick Start
-    url: '#quick-start'
-    id: quick-start
     children:
       - page: Java
         url: /docs/quickstart/java.html
   - page: Guides
-    url: '#guides'
-    id: guides
     children:
       - page: Model Definition
         url: /docs/guides/model-definition.html
@@ -90,22 +76,16 @@ doc_side_nav:
       - page: Defining Aggregate
         url: /docs/guides/defining-aggregate.html
       - page: Related Guides
-        url: '#related-guides'
-        id: related-guides
         children:
           - page: Protocol Buffers
             url: https://developers.google.com/protocol-buffers/docs/overview
           - page: gRPC
             url: https://grpc.io/docs/guides/index.html
   - page: Tutorials
-    url: '#tutorials'
-    id: tutorials
     children:
       - page: Overview
         url: /docs/tutorials/
       - page: Basic
-        url: '#basic-tutorials'
-        id: basic-tutorials
         children:
           - page: Java
             url: /docs/tutorials/basic/java.html
@@ -114,24 +94,16 @@ doc_side_nav:
           - page: C++
             url: /docs/tutorials/basic/cpp.html
   - page: Client Libraries
-    url: '#client-libs'
-    id: client-libs
     children:
       - page: Java
-        url: '#lib-java'
-        id: lib-java
         children:
           - page: API Reference
             url: https://spine.io/core-java/javadoc/client/index.html
       - page: JavaScript
-        url: '#lib-js'
-        id: lib-js
         children:
           - page: API Reference
             url: https://spine.io/docs/reference/javascript/index.html
       - page: Dart
-        url: '#lib-dart'
-        id: lib-dart
         children:
           - page: API Reference
             url: https://spine.io/docs/reference/dart/index.html

--- a/_includes/doc-side-nav.html
+++ b/_includes/doc-side-nav.html
@@ -14,16 +14,16 @@
                    aria-expanded="false">
                 {{ item.page }}
                 </a>
-                {% if item.sub_nav[0] %}
-                <ul id="{{ item.sub_nav_id }}" class="sub-nav collapse">
-                    {% for entry in item.sub_nav %}
+                {% if item.children[0] %}
+                <ul id="{{ item.id }}" class="sub-nav collapse">
+                    {% for entry in item.children %}
                     <li><a class="side-nav-link {% if entry.url == page.url %}active{% endif %}"
                            href="{{ entry.url }}">
                         {{ entry.page }}
                         </a>
-                        {% if entry.sub_sub_nav[0] %}
-                        <ul id="{{ entry.sub_sub_nav_id }}" class="sub-nav collapse">
-                            {% for subentry in entry.sub_sub_nav %}
+                        {% if entry.children[0] %}
+                        <ul id="{{ entry.id }}" class="sub-nav collapse">
+                            {% for subentry in entry.children %}
                             <li><a class="side-nav-link {% if subentry.url == page.url %}active{% endif %}"
                                    href="{{ subentry.url }}">
                                 {{ subentry.page }}

--- a/_includes/doc-side-nav.html
+++ b/_includes/doc-side-nav.html
@@ -9,20 +9,22 @@
     </div>
     {% if site.data.navigation.doc_side_nav.doc_side_nav %}
         {% for item in site.data.navigation.doc_side_nav.doc_side_nav %}
+            {% assign collapsedElId = item.page | slugify %}
             <li><a class="side-nav-link {% if item.url == page.url %}active{% endif %}"
-                   href="{{ item.url }}"
+                   href="{% if item.children %}#{{ collapsedElId }}{% else %}{{ item.url }}{% endif %}"
                    aria-expanded="false">
                 {{ item.page }}
                 </a>
                 {% if item.children[0] %}
-                <ul id="{{ item.id }}" class="sub-nav collapse">
+                <ul id="{{ collapsedElId }}" class="sub-nav collapse">
                     {% for entry in item.children %}
+                    {% assign collapsedEntryId = entry.page | slugify %}
                     <li><a class="side-nav-link {% if entry.url == page.url %}active{% endif %}"
-                           href="{{ entry.url }}">
+                           href="{% if entry.children %}#{{ collapsedEntryId }}{% else %}{{ entry.url }}{% endif %}">
                         {{ entry.page }}
                         </a>
                         {% if entry.children[0] %}
-                        <ul id="{{ entry.id }}" class="sub-nav collapse">
+                        <ul id="{{ collapsedEntryId }}" class="sub-nav collapse">
                             {% for subentry in entry.children %}
                             <li><a class="side-nav-link {% if subentry.url == page.url %}active{% endif %}"
                                    href="{{ subentry.url }}">


### PR DESCRIPTION
This PR brings simplified attribute names for side navigation.
Also, the `REAMDE.md` file was updated.

The new structure for the three-level navigation list:
```
doc_side_nav:
  - page: Messaging
    children:
      - page: Architecture Overview
        url: /docs/architecture-overview.html
      - page: Event
        children:
          - page: New page on the 3rd level
            url: /docs/3rd-level-file.html
```

The `id` and `href` that are needed to create a collapsible navigation item now will be generated automatically based on a page name in the `_includes/doc-side-nav.html` file.

Result:

![image](https://user-images.githubusercontent.com/22611365/73057752-f684b780-3e9a-11ea-9bd3-2af9ba5c8265.png)

