### PR TITLE
Cleanup `.md` file attributes

### DIFF
--- a/docs/motivation.md
+++ b/docs/motivation.md
@@ -3,7 +3,6 @@ title: Why we created Spine
 headline: Motivation
 bodyclass: docs
 layout: docs
-type: markdown
 ---
 
 # Why we created Spine

--- a/docs/prior-art.md
+++ b/docs/prior-art.md
@@ -3,7 +3,6 @@ title: Prior Art
 headline: Prior Art
 bodyclass: docs
 layout: docs
-type: markdown
 ---
 
 # Prior Art

--- a/docs/tutorials/basic/cpp.md
+++ b/docs/tutorials/basic/cpp.md
@@ -3,9 +3,6 @@ title: Spine Basics - C++
 headline: Spine Basics - C++
 bodyclass: docs
 layout: docs
-sidenav_list: tutorials
-sidenav: doc-side-nav.html
-type: markdown
 ---
 
 <p class="coming-soon">Coming soon...</p>

--- a/docs/tutorials/basic/java.md
+++ b/docs/tutorials/basic/java.md
@@ -3,9 +3,6 @@ title: Spine Basics - Java
 headline: Spine Basics - Java
 bodyclass: docs
 layout: docs
-sidenav_list: tutorials
-sidenav: doc-side-nav.html
-type: markdown
 ---
 <p class="coming-soon">Coming soon...</p>
 

--- a/docs/tutorials/basic/javascript.md
+++ b/docs/tutorials/basic/javascript.md
@@ -1,11 +1,8 @@
 ---
 title: Spine Basics - JavaScript
 headline: Spine Basics - JavaScript
-layout: docs
 bodyclass: docs
-sidenav_list: tutorials
-sidenav: doc-side-nav.html
-type: markdown
+layout: docs
 ---
 
 <p class="coming-soon">Coming soon...</p>

--- a/docs/tutorials/basic/swift.md
+++ b/docs/tutorials/basic/swift.md
@@ -3,9 +3,6 @@ title: Spine Basics - Swift
 headline: Spine Basics - Swift
 bodyclass: docs
 layout: docs
-sidenav_list: tutorials
-sidenav: doc-side-nav.html
-type: markdown
 ---
 <p class="coming-soon">Coming soon...</p>
 

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -3,9 +3,6 @@ title: Tutorials
 headline: Tutorials
 bodyclass: docs
 layout: docs
-type: markdown
-sidenav_list: tutorials
-sidenav: doc-side-nav.html
 ---
 
 This section contains tutorials for each of the languages our framework supports.

--- a/js/common.js
+++ b/js/common.js
@@ -33,6 +33,7 @@ const phoneMedium = 480;
 const phoneXLarge = 640;
 
 $(function() {
+    fixHead();
     changeCodeColor();
     initPrettyprint();
     openHeaderMenuOnMobile();


### PR DESCRIPTION
This PR closes #234 

In this PR the obsolete `.md` file attributes were removed.
The `header` was fixed for the situation when the user followed the link to a specific section of the page.