### PR TITLE
Add JavaScript example links

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -20,8 +20,8 @@ Links to smaller examples are listed below.
 
 ## JavaScript
 
-<p class="coming-soon">Coming soon...</p>
+<ul>
+    <li><a target="_blank" href="https://github.com/spine-examples/todo-list/tree/master/client/html-js">Simple HTML/JS ToDo List client</a> — a client app with very basic features.</li>
+    <li><a target="_blank" href="https://github.com/spine-examples/todo-list/tree/master/client/angular">ToDo List client on Angular</a> — more featured client built with Angular 7.</li>
+</ul>
 
-## C++
-
-<p class="coming-soon">Coming soon...</p>

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -22,6 +22,6 @@ Links to smaller examples are listed below.
 
 <ul>
     <li><a target="_blank" href="https://github.com/spine-examples/todo-list/tree/master/client/html-js">Simple HTML/JS ToDo List client</a> — a client app with very basic features.</li>
-    <li><a target="_blank" href="https://github.com/spine-examples/todo-list/tree/master/client/angular">ToDo List client on Angular</a> — more featured client built with Angular 7.</li>
+    <li><a target="_blank" href="https://github.com/spine-examples/todo-list/tree/master/client/angular">ToDo List client on Angular</a> — a more featured client built with Angular 7.</li>
 </ul>
 


### PR DESCRIPTION
This PR:
  * Removes C++ section of examples.
  * Adds links to JS-related examples from the ToDo List project.