### PR TITLE
Update `FAQ` page styles in accordance with the new style of the main text

### DIFF
--- a/_sass/base/_common.scss
+++ b/_sass/base/_common.scss
@@ -234,7 +234,7 @@ th {
 
 // Expandable title with caret icon before
 %expandable-title {
-  font-size: $font-size--s;
+  font-size: $font-size--primary;
   line-height: 1.5;
   color: $black;
   font-weight: 500;
@@ -254,7 +254,7 @@ th {
 
   // Initial state of the title
   &.collapsed {
-    color: rgba($black, .54);
+    color: $textColor;
     font-weight: 400;
 
     &:before {

--- a/_sass/base/_markdown.scss
+++ b/_sass/base/_markdown.scss
@@ -58,6 +58,10 @@ $article-line-height: 1.74;
   ul {
     margin: 0 0 32px 6px;
 
+    @media (max-width: $tablet) {
+      margin-bottom: 24px;
+    }
+
     li {
       margin-left: 18px;
       margin-top: .6em;

--- a/_sass/pages/_faq.scss
+++ b/_sass/pages/_faq.scss
@@ -1,8 +1,9 @@
 $content-top-offset: 48px;
 $faq-title-padding: 16px 0 16px $icon-right-offset;
-$faq-content-padding: 0 $icon-right-offset;
-$faq-content-padding-mobile: 0 $icon-right-offset 24px;
+$faq-content-padding: 24px $icon-right-offset;
+$faq-content-padding-mobile: 8px $icon-right-offset 16px;
 $anchor-icon-size: 16px;
+$faq-title-background: #f7f8f8;
 $faq-item-divider: 1px dotted #d7d7d7;
 $space-for-icon: 32px;
 
@@ -33,18 +34,25 @@ $space-for-icon: 32px;
   }
 
   .faq-item {
-    @media (max-width: $tablet) {
-      border-bottom: $faq-item-divider;
-    }
+    border-bottom: $faq-item-divider;
 
     .faq-heading {
-      display: inline-block;
+      display: block;
       padding: $faq-title-padding;
+      background: $faq-title-background;
       cursor: pointer;
       @extend %expandable-title;
 
       @media (max-width: $tablet) {
         padding-right: 20px;
+      }
+
+      &.collapsed {
+        background: none;
+
+        &:hover {
+          background: $faq-title-background;
+        }
       }
 
       span {

--- a/faq/index.html
+++ b/faq/index.html
@@ -7,7 +7,7 @@ headline: 'Frequently Asked Questions'
 ---
 <div class="container-fluid content-holder">
     <div class="row">
-        <div class="col-md-9 faq-container">
+        <div class="col-12 faq-container">
             <ul class="faq-list">
                 <li class="faq-item">
                     {% assign questionID01 = 'why-spine' %}
@@ -22,7 +22,7 @@ headline: 'Frequently Asked Questions'
                         </a>
                     </h6>
                     <div id="{{ questionID01 }}" class="faq-content collapse">
-                        <div class="faq-content-wrapper">
+                        <div class="faq-content-wrapper markdown">
                             <p>We want to give our users a framework that provides an infrastructure
                                 and connects the “service” parts of applications with their “brains”,
                                 or in other words, business logic. Find out how
@@ -45,7 +45,7 @@ headline: 'Frequently Asked Questions'
                         </a>
                     </h6>
                     <div id="{{ questionID02 }}" class="faq-content collapse">
-                        <div class="faq-content-wrapper">
+                        <div class="faq-content-wrapper markdown">
                             <p>As Protocol Buffers are already implemented in a variety of languages, they make
                                 interoperability between polyglot applications in your architecture much simpler.
                                 If you’re introducing a new service with one in Ruby or Go, or even communicating with a
@@ -73,7 +73,7 @@ headline: 'Frequently Asked Questions'
                         </a>
                     </h6>
                     <div id="{{ questionID03 }}" class="faq-content collapse">
-                        <div class="faq-content-wrapper">
+                        <div class="faq-content-wrapper markdown">
                             <p>Have a look at the <a href="https://capnproto.org/news/2014-06-17-capnproto-flatbuffers-sbe.html">comparison matrix</a>
                                 created by Kenton Varda, the author of Protobuf v2 and Cap'n Proto.
                                 Here are the main features that make Protobuf the best choice for our framework:</p>
@@ -101,7 +101,7 @@ headline: 'Frequently Asked Questions'
                         </a>
                     </h6>
                     <div id="{{ questionID04 }}" class="faq-content collapse">
-                        <div class="faq-content-wrapper">
+                        <div class="faq-content-wrapper markdown">
                             <p>The framework is based on and supports only
                                 <a href="https://developers.google.com/protocol-buffers/docs/proto3">
                                     proto3 dialect</a>.</p>
@@ -121,7 +121,7 @@ headline: 'Frequently Asked Questions'
                         </a>
                     </h6>
                     <div id="{{ questionID05 }}" class="faq-content collapse">
-                        <div class="faq-content-wrapper">
+                        <div class="faq-content-wrapper markdown">
                             <p>Here are our plans for the future versions of Spine:</p>
                             <ul>
                                 <li><b>Release version 1.0;</b></li>
@@ -129,15 +129,13 @@ headline: 'Frequently Asked Questions'
                             </ul>
                             <p>We shall also concentrate on coverage of popular programming languages
                                 and technologies:</p>
-                            <div class="markdown">
-                                <ul>
-                                    <li><b>Node.js</b> to enable
-                                        <a href="{{ site.baseurl }}/docs/introduction/concepts.html#projection">Projections</a>
-                                        development by our users creating UI.</li>
-                                    <li><b>Kotlin</b> client library.</li>
-                                    <li><b>Swift</b> client library.</li>
-                                </ul>
-                            </div>
+                            <ul>
+                                <li><b>Node.js</b> to enable
+                                    <a href="{{ site.baseurl }}/docs/introduction/concepts.html#projection">Projections</a>
+                                    development by our users creating UI.</li>
+                                <li><b>Kotlin</b> client library.</li>
+                                <li><b>Swift</b> client library.</li>
+                            </ul>
                         </div>
                     </div>
                 </li>


### PR DESCRIPTION
This PR brings updated styles for the `FAQ` page in accordance with the new style of the main text.
Added faq item dividers and gray background for the open item.

![image](https://user-images.githubusercontent.com/22611365/75680053-66a40b80-5c99-11ea-8596-e5ab0a9c6eff.png)
