### PR TITLE
Rules page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,9 +206,9 @@ GEM
       jekyll-seo-tag (~> 2.1)
     minitest (5.14.0)
     multipart-post (2.1.1)
-    nokogiri (1.10.8)
+    nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
-    nokogiri (1.10.8-x64-mingw32)
+    nokogiri (1.10.9-x64-mingw32)
       mini_portile2 (~> 2.4.0)
     octokit (4.16.0)
       faraday (>= 0.9)
@@ -240,7 +240,7 @@ GEM
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.1)
-    zeitwerk (2.2.2)
+    zeitwerk (2.3.0)
 
 PLATFORMS
   ruby

--- a/_data/navigation/doc_side_nav.yml
+++ b/_data/navigation/doc_side_nav.yml
@@ -3,6 +3,8 @@ doc_side_nav:
     children:
       - page: Motivation
         url: /docs/introduction/
+      - page: Rules
+        url: /docs/introduction/rules.html
       - page: Development Process
         url: /docs/introduction/development.html
       - page: Architecture

--- a/docs/introduction/naming-conventions.md
+++ b/docs/introduction/naming-conventions.md
@@ -15,13 +15,6 @@ that we find useful for making the code easier to understand.</p>
 Proto files are named using the `snake_case`, as defined by Protobuf. There are several special
 kinds of files.
 
-<p class="note">We recommend using `java_outer_classname` in proto files names to make their names
-    obvious. Otherwise Protobuf Compiler tries to use the name of the file for the Java class.
-    For example, for `identifiers.proto` it will be `Identifiers.java`.
-    Though sometimes it can be `SomethingOuterClass` when there is a type which conflicts with
-    CamelCase version of the file name. You may also want to use names like `Identifiers` for
-    utility classes related to your domain.</p>
-
 ### Identifiers   
 
 Commands and events reference model entities using their identifiers. 
@@ -41,7 +34,7 @@ corresponding Bounded Context.
 
 Commands are defined in a file ending with `commands.proto`. 
 It can be simply `commands.proto` but usually commands are handled by different entities. 
-Thus it is convenient to name such file after the type of a target entity, 
+Thus, it is convenient to name such a file after the type of the target entity, 
 for example, an aggregate: 
 
  * `blog_commands.proto` 

--- a/docs/introduction/rules.md
+++ b/docs/introduction/rules.md
@@ -8,11 +8,11 @@ type: markdown
 
 # Rules
 
-Here are the basic rules the framework is built upon:
+Here are the ground rules the framework is built upon:
 
 1. An update to a business model <em>is</em> an event. 
 
-2. All other data are built in response to events.
+2. Entities are changed in response to events.
    
 3. A command has one and <em>only one</em> handler.
 

--- a/docs/introduction/rules.md
+++ b/docs/introduction/rules.md
@@ -1,0 +1,22 @@
+---
+title: Rules
+headline: Documentation
+bodyclass: docs
+layout: docs
+type: markdown
+---
+
+# Rules
+
+Here are the basic rules the framework is built upon:
+
+1. An update to a business model <em>is</em> an event. 
+
+2. All other data are built in response to events.
+   
+3. A command has one and <em>only one</em> handler.
+
+4. A command <em>must</em> result in an event, a rejection, or other commands.
+
+5. Events are <em>always</em> appended. Never deleted or edited.
+ 


### PR DESCRIPTION
This PR:
  * Adds the Rules page into the Introduction section.
  * Removes the note block from the Naming Conventions page. This note should be [given](#265) in the document which explains creating a proto file.
 * Bumps some dependencies.
