### PR TITLE
Update references to generated doc

### DIFF
--- a/_data/navigation/doc_side_nav.yml
+++ b/_data/navigation/doc_side_nav.yml
@@ -49,19 +49,22 @@ doc_side_nav:
             url: /docs/tutorials/basic/javascript.html
           - page: C++
             url: /docs/tutorials/basic/cpp.html
-  - page: Client Libraries
+  - page: API References
     children:
-      - page: Java
+      - page: Java Server
+        url: https://spine.io/core-java/reference/server/index.html
+      - page: Java Client
+        url: https://spine.io/core-java/reference/client/index.html
+      - page: Java Web Server
         children:
-          - page: API Reference
-            url: https://spine.io/core-java/javadoc/client/index.html
-      - page: JavaScript
-        children:
-          - page: API Reference
-            url: https://spine.io/docs/reference/javascript/index.html
-      - page: Dart
-        children:
-          - page: API Reference
-            url: https://spine.io/docs/reference/dart/index.html
+          - page: API
+            url: https://spine.io/web/reference/web/index.html
+          - page: Implementation on Firebase
+            url: https://spine.io/web/reference/firebase-web/index.html
+      - page: JavaScript Client
+        url: https://spine.io/web/reference/client-js/index.html
+      - page: Dart Client
+        url: https://spine.io/dart/reference/client/index.html
+
   - page: Examples
     url: /docs/examples/

--- a/_data/navigation/doc_side_nav.yml
+++ b/_data/navigation/doc_side_nav.yml
@@ -49,7 +49,7 @@ doc_side_nav:
             url: /docs/tutorials/basic/javascript.html
           - page: C++
             url: /docs/tutorials/basic/cpp.html
-  - page: API References
+  - page: API Reference
     children:
       - page: Java Server
         url: https://spine.io/core-java/reference/server/index.html

--- a/_includes/feature-section.html
+++ b/_includes/feature-section.html
@@ -47,11 +47,11 @@
             <div class="card-content-text">
                 <header class="feature-card-title">Clear API</header>
                 <p>Concepts from the DDD books, such as
-                    <code><a href="https://spine.io/core-java/javadoc/server/io/spine/server/aggregate/Aggregate.html">Aggregate</a></code>,
-                    <code><a href="https://spine.io/core-java/javadoc/server/io/spine/server/projection/Projection.html">Projection</a></code>,
-                    <code><a href="https://spine.io/core-java/javadoc/server/io/spine/server/procman/ProcessManager.html">ProcessManager</a></code>,
-                    <code><a href="https://spine.io/core-java/javadoc/server/io/spine/server/entity/Repository.html">Repository</a></code> are right in the code.
-                    Ever guessed how to cook a <code><a href="https://spine.io/core-java/javadoc/server/io/spine/server/BoundedContext.html">BoundedContext</a></code>?
+                    <code><a href="https://spine.io/core-java/reference/server/io/spine/server/aggregate/Aggregate.html">Aggregate</a></code>,
+                    <code><a href="https://spine.io/core-java/reference/server/io/spine/server/projection/Projection.html">Projection</a></code>,
+                    <code><a href="https://spine.io/core-java/reference/server/io/spine/server/procman/ProcessManager.html">ProcessManager</a></code>,
+                    <code><a href="https://spine.io/core-java/reference/server/io/spine/server/entity/Repository.html">Repository</a></code> are right in the code.
+                    Ever guessed how to cook a <code><a href="https://spine.io/core-java/reference/server/io/spine/server/BoundedContext.html">BoundedContext</a></code>?
                     Guess no more!
                 </p>
             </div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -15,7 +15,7 @@
             <li><p><a href="{{ site.baseurl }}/docs/quickstart">Quick Start</a></p></li>
             <li><p><a href="{{ site.baseurl }}/docs/guides">Guides</a></p></li>
             <li><p><a href="{{ site.baseurl }}/docs/tutorials">Tutorials</a></p></li>
-            <li><p><a href="{{ site.baseurl }}/docs/reference">API Reference</a></p></li>
+            <li><p><a href="{{ site.baseurl }}/docs">API Reference</a></p></li>
           </ul>
         </div>
         <hr class="footer-sections" />

--- a/_posts/2020-03-02-integrating-with-a-third-party.md
+++ b/_posts/2020-03-02-integrating-with-a-third-party.md
@@ -135,7 +135,7 @@ The event producer obtains cached historical events, matches them to the receive
 and sends them to the client. The **Takeoffs and Landings** system implements 
 an&nbsp;[event consumer](https://github.com/spine-examples/airport/blob/master/takeoffs-and-landings/src/main/java/io/spine/example/airport/tl/supplies/SuppliesEventConsumer.java)
 which constructs a subscription and maintains it as long as the system needs to receive more events.
-The consumer broadcasts the received Events via an instance of [`ThirdPartyContext`](https://spine.io/core-java/javadoc/server/io/spine/server/integration/ThirdPartyContext.html):
+The consumer broadcasts the received Events via an instance of [`ThirdPartyContext`](https://spine.io/core-java/reference/server/io/spine/server/integration/ThirdPartyContext.html):
 
 ```java
 @Override
@@ -278,7 +278,7 @@ which performs all the technical work of obtaining and validating data, and a [P
 for the [Boarding process](https://github.com/spine-examples/airport/blob/master/takeoffs-and-landings/src/main/java/io/spine/example/airport/tl/passengers/BoardingProcman.java).
 The **Security Checks** API provides data for each passenger independently. The client polls
 the data and publishes many intermediate `PassengerBoarded` or `PassengerDeniedBoarding` external
-events via [`ThirdPartyContext`](https://spine.io/core-java/javadoc/server/io/spine/server/integration/ThirdPartyContext.html):
+events via [`ThirdPartyContext`](https://spine.io/core-java/reference/server/io/spine/server/integration/ThirdPartyContext.html):
 
 ```java
 public void start() {

--- a/about/index.html
+++ b/about/index.html
@@ -22,7 +22,7 @@ headline: 'About Spine'
                 <p>The data model is defined in Protobuf and compiled into performant code in
                     multiple languages. The backend logic is written in Java.
                     Client libraries are available for
-                    <a href="https://spine.io/core-java/javadoc/client/index.html">Java</a>,
+                    <a href="https://spine.io/core-java/reference/client/index.html">Java</a>,
                     <a href="https://github.com/SpineEventEngine/web">JavaScript</a>, and
                     <a href="https://github.com/SpineEventEngine/dart">Dart</a>.
                 </p>

--- a/docs/introduction/concepts.md
+++ b/docs/introduction/concepts.md
@@ -106,7 +106,7 @@ generates events in response to changes in the domain.
 
 <p class="note">In some cases, Event Reactor may ignore the event, returning `Nothing`.
     It usually happens when a method returns one of the
-    [`Either`](https://spine.io/core-java/javadoc/server/index.html) types, with `Nothing` as
+    [`Either`](https://spine.io/core-java/reference/server/index.html) types, with `Nothing` as
     one of the possible options: `EitherOf2<TaskReAssigned, Nothing>`.</p>
 
 ## Value Objects
@@ -181,9 +181,9 @@ Repository encapsulates storage, retrieval, and search of Entities as if it were
 a collection of objects. It isolates domain objects from the details of the database access code. 
 
 The applications you develop using Spine usually have the following types of repositories:
-* [`AggregateRepository`](https://spine.io/core-java/javadoc/server/io/spine/server/aggregate/AggregateRepository.html),
-* [`ProcessManagerRepository`](https://spine.io/core-java/javadoc/server/io/spine/server/procman/ProcessManagerRepository.html),
-* [`ProjectionRepository`](https://spine.io/core-java/javadoc/server/io/spine/server/projection/ProjectionRepository.html).
+* [`AggregateRepository`](https://spine.io/core-java/reference/server/io/spine/server/aggregate/AggregateRepository.html),
+* [`ProcessManagerRepository`](https://spine.io/core-java/reference/server/io/spine/server/procman/ProcessManagerRepository.html),
+* [`ProjectionRepository`](https://spine.io/core-java/reference/server/io/spine/server/projection/ProjectionRepository.html).
 
 ### Snapshot
 

--- a/docs/introduction/development.md
+++ b/docs/introduction/development.md
@@ -215,7 +215,7 @@ assertEntity.hasStateThat()
 ### Configuring Server Environment
 
 For information on configuring server environment of a Spine-based application, please 
-see the reference documentation of the [`ServerEnvironment`](https://spine.io/core-java/javadoc/server/io/spine/server/ServerEnvironment.html)
+see the reference documentation of the [`ServerEnvironment`](https://spine.io/core-java/reference/server/io/spine/server/ServerEnvironment.html)
 class.
 
 ### Assembling Application


### PR DESCRIPTION
Since recently, more generated documentation is published to `spine.io`. In this PR we add links to the new docs and update links to the docs which have changed their directory structure.

Also, the link to "API Reference" on the home page now leads to the general "Docs" page, as we've got no special page for API reference overview and I'm not convinced that we need one.