### PR TITLE
Fix the OS Licenses page

### DIFF
--- a/_layouts/licenses.html
+++ b/_layouts/licenses.html
@@ -6,7 +6,7 @@ bodyclass: licenses
 
 <div class="container-fluid content-holder">
     <div class="row">
-        <div class="col-md {{ page.type }} licenses-list">
+        <div class="col-md licenses-list">
             {{ content }}
         </div>
     </div>

--- a/_sass/base/_markdown.scss
+++ b/_sass/base/_markdown.scss
@@ -54,43 +54,7 @@ $article-line-height: 1.74;
     padding-bottom: 8px;
   }
 
-  ol,
-  ul {
-    margin: 0 0 32px 6px;
-
-    @media (max-width: $tablet) {
-      margin-bottom: 24px;
-    }
-
-    li {
-      margin-left: 18px;
-      margin-top: .6em;
-      padding-left: 6px; // Adds additional space between bullet and text.
-
-      ol,
-      ul {
-        margin-bottom: 32px;
-
-        li {
-          margin-top: .45em;
-        }
-      }
-    }
-  }
-
-  ul {
-    list-style: disc;
-
-    li {
-      ul {
-        list-style: circle;
-      }
-    }
-  }
-
-  ol {
-    list-style: decimal;
-  }
+  @include list($item-line-height: $article-line-height);
 
   // Section Headlines
   h1 {

--- a/_sass/base/_mixins.scss
+++ b/_sass/base/_mixins.scss
@@ -85,3 +85,44 @@
   opacity: .26;
   @include transition(all .3s ease-in-out);
 }
+
+// Ordered and unordered list styles.
+// Usage: `@include list();`
+@mixin list($item-line-height: 1.6) {
+  ol, ul {
+    margin: 0 0 32px 6px;
+    line-height: $item-line-height;
+
+    @media (max-width: $tablet) {
+      margin-bottom: 24px;
+    }
+
+    li {
+      margin-left: 18px;
+      margin-top: .6em;
+      padding-left: 6px; // Adds additional space between bullet and text.
+
+      ol, ul {
+        margin-bottom: 32px;
+
+        li {
+          margin-top: .45em;
+        }
+      }
+    }
+  }
+
+  ul {
+    list-style: disc;
+
+    li {
+      ul {
+        list-style: circle;
+      }
+    }
+  }
+
+  ol {
+    list-style: decimal;
+  }
+}

--- a/_sass/pages/_about.scss
+++ b/_sass/pages/_about.scss
@@ -41,7 +41,7 @@
 
     &:hover {
       transform: translateY(-2px);
-      box-shadow: 0 6px 12px rgba(0, 0, 0, .12);
+      box-shadow: 0 6px 12px rgba(black, .12);
     }
 
     &.external {
@@ -60,7 +60,7 @@
     padding-bottom: 64px;
     text-align: center;
 
-    @media(max-width: $tablet) {
+    @media (max-width: $tablet) {
       padding-top: 24px;
       padding-bottom: 64px;
     }
@@ -68,10 +68,9 @@
     .section-title {
       font-size: 2rem;
       color: $black;
-      //margin: 88px 0 12px;
       cursor: default;
 
-      @media(max-width: $tablet) {
+      @media (max-width: $tablet) {
         margin-top: 64px;
       }
     }

--- a/_sass/pages/_about.scss
+++ b/_sass/pages/_about.scss
@@ -18,45 +18,7 @@
       margin-top: 16px;
     }
 
-    ol,
-    ul {
-      margin: 0 0 32px 6px;
-
-      @media (max-width: $tablet) {
-        margin-bottom: 24px;
-      }
-
-      li {
-        line-height: 1.6;
-        margin-left: 18px;
-        margin-top: .6em;
-        padding-left: 6px; // Adds additional space between bullet and text.
-        margin-bottom: 12px;
-
-        ol,
-        ul {
-          margin-bottom: 32px;
-
-          li {
-            margin-top: .45em;
-          }
-        }
-      }
-    }
-
-    ul {
-      list-style: disc;
-
-      li {
-        ul {
-          list-style: circle;
-        }
-      }
-    }
-
-    ol {
-      list-style: decimal;
-    }
+    @include list();
   }
 
   .logo-card {

--- a/_sass/pages/_licenses.scss
+++ b/_sass/pages/_licenses.scss
@@ -111,8 +111,8 @@ $panel-hover-color: rgba($mainBrandColor, .04);
 
   .dependencies-container,
   .report-info {
-    padding: 0 $inner-content-offset;
-    margin: 16px 0 8px; // Top and bottom margins prevents content jumping
+    padding: 16px $inner-content-offset 8px; // Top and bottom paddings prevent content jumping
+    margin: 0 0 8px;
 
     @media (max-width: $tablet) {
       padding: 0 20px;

--- a/_sass/pages/_licenses.scss
+++ b/_sass/pages/_licenses.scss
@@ -18,6 +18,8 @@ $panel-hover-color: rgba($mainBrandColor, .04);
     padding-left: 0;
     padding-right: 0;
   }
+
+  @include list();
 }
 
 .licenses {

--- a/os-licenses/index.html
+++ b/os-licenses/index.html
@@ -3,7 +3,6 @@ layout: licenses
 title: Open-Source Libraries and Licenses
 headline: Open-Source Libraries and Licenses
 bodyclass: licenses
-type: markdown
 ---
 
 <div class="row">


### PR DESCRIPTION
This PR closes #274 and closes #273 issues.

In this PR the ordered and unordered list styles were moved to the new mixin to avoid code duplication. The `markdown` page type was removed from the OS Licenses page to fix the layout.