### PR TITLE
Update sticky menu color and fix `Blog` page layout

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -7,8 +7,11 @@ bodyclass: post
 {% include color-selector.html %}
 
 <div class="container-fluid content-holder post-container">
-    <div class="row justify-post-container">
-        <div class="col-lg-7 article-container markdown">
+    <div class="row">
+        <!-- The empty div is needed to align the middle block exactly in the center.
+         The layout is the same as on the `docs` pages. -->
+        <div class="col-lg empty-block side-nav-col"></div>
+        <div class="col-12 col-lg article-container markdown">
             <article class="post-wrapper">
                 <h1>{{ page.title }}</h1>
                 <div class="post-info">

--- a/_posts/2018-05-21-blog-is-now-live.md
+++ b/_posts/2018-05-21-blog-is-now-live.md
@@ -3,7 +3,7 @@ layout: post
 title: Blog is now live
 published: true
 bodyclass: post
-header_type: fixed-dark-header
+header_type: fixed-header
 ---
 
 As we are getting closer to `1.0-GA` release of the framework we thought that it would be nice to start blogging about the framework development, the ES/CQRS-based projects, our insights etc.

--- a/_posts/2018-05-22-migrating-to-java-8.md
+++ b/_posts/2018-05-22-migrating-to-java-8.md
@@ -3,7 +3,7 @@ layout: post
 title: Migrating to Java 8
 published: true
 bodyclass: post
-header_type: fixed-dark-header
+header_type: fixed-header
 ---
 
 Starting the upcoming `0.11.0` release the minimal version of Java for Spine-based application will become Java 8. Early adopters can already see the first sights of Java 8 migration in core framework modules.

--- a/_posts/2019-08-21-spine-event-engine-1-0-is-out.md
+++ b/_posts/2019-08-21-spine-event-engine-1-0-is-out.md
@@ -3,7 +3,7 @@ layout: post
 title: Spine Event Engine 1.0 is Out!
 published: true
 bodyclass: post
-header_type: fixed-dark-header
+header_type: fixed-header
 ---
 
 We are glad to announce the release of the first production-ready version of Spine Event Engine!

--- a/_posts/2020-03-02-integrating-with-a-third-party.md
+++ b/_posts/2020-03-02-integrating-with-a-third-party.md
@@ -3,7 +3,7 @@ layout: post
 title: Integrating with a third party
 published: true
 bodyclass: post
-header_type: fixed-dark-header
+header_type: fixed-header
 author: Dmytro Dashenkov
 ---
 

--- a/_posts/2020-03-02-integrating-with-a-third-party.md
+++ b/_posts/2020-03-02-integrating-with-a-third-party.md
@@ -67,6 +67,7 @@ an accurate representation.
 
 ## Customer/Supplier Contexts
 
+{: .img-small}
 ![Customer/Supplier Contexts domain]({{ site.baseurl }}/img/integrating-with-a-3d-party/customer-supplier.jpg)
 
 The **Takeoffs and Landings** system must know whether an *Aircraft* is ready for the *Flight*.

--- a/_sass/base/_colors.scss
+++ b/_sass/base/_colors.scss
@@ -5,6 +5,7 @@ $thirdBrandColor: #ddeaf4;
 $inverseBrandColor: #FFFFFF;
 $body-light-gray-color: #f6f8fA;
 $warningColor: #deba32;
+$nav-blue-gradient: linear-gradient(152deg, #1378DA 0%, #0B64CC 100%);
 
 // Dividers
 $dividerColor: rgba(0, 0, 0, .08);

--- a/_sass/modules/_hero.scss
+++ b/_sass/modules/_hero.scss
@@ -1,6 +1,6 @@
 // Background for nav and hero
 .nav-hero-container {
-  background-image: linear-gradient(152deg, #1378DA 0%, #0B64CC 100%);
+  background-image: $nav-blue-gradient;
   position: relative;
   padding-bottom: 12px;
 

--- a/_sass/modules/_nav.scss
+++ b/_sass/modules/_nav.scss
@@ -17,9 +17,9 @@
   z-index: 1000;
   position: absolute;
 
-  // Fixed dark header for small pages like Privacy Statement and Posts
-  // To use add `header-type: fixed-dark-header` on the page
-  &.fixed-dark-header {
+  // Fixed header for small pages such us `Privacy Statement` and `Post`.
+  // Usage: add the `header_type: fixed-header` attribute to the front matter block.
+  &.fixed-header {
     background-image: $nav-blue-gradient;
     position: fixed;
     height: $header-height;

--- a/_sass/modules/_nav.scss
+++ b/_sass/modules/_nav.scss
@@ -20,7 +20,7 @@
   // Fixed dark header for small pages like Privacy Statement and Posts
   // To use add `header-type: fixed-dark-header` on the page
   &.fixed-dark-header {
-    background-color: $footerColor;
+    background-image: $nav-blue-gradient;
     position: fixed;
     height: $header-height;
 
@@ -196,7 +196,7 @@
     display: block;
     position: fixed;
     height: $header-height;
-    background-color: $footerColor;
+    background-image: $nav-blue-gradient;
 
     &.pinned {
       @include translateY(-100%);

--- a/_sass/pages/_about.scss
+++ b/_sass/pages/_about.scss
@@ -1,4 +1,8 @@
 .about {
+  .section-title {
+    font-size: $font-size--xl;
+  }
+
   .principles-section {
     background-color: $light-gray-blue;
     padding-top: 56px;
@@ -7,10 +11,6 @@
 
     @media(max-width: $tablet){
       padding-top: 32px;
-    }
-
-    .section-title {
-      font-size: $font-size--xl;
     }
 
     .link {

--- a/_sass/pages/_blog.scss
+++ b/_sass/pages/_blog.scss
@@ -195,4 +195,10 @@
   .btn-back {
     margin-top: 32px;
   }
+
+  .img-small {
+    img {
+      width: 70%;
+    }
+  }
 }

--- a/_sass/pages/_blog.scss
+++ b/_sass/pages/_blog.scss
@@ -167,11 +167,9 @@
     margin-top: $page-top-offset;
   }
 
-  .justify-post-container {
-    justify-content: flex-end !important;
-
+  .empty-block {
     @media (max-width: $desktop-small) {
-      justify-content: center !important;
+      display: none;
     }
   }
 

--- a/_sass/pages/_landing.scss
+++ b/_sass/pages/_landing.scss
@@ -92,7 +92,7 @@
 
 // Documentation call to action
 .doc-call-container {
-  background-color: $secondBrandColor;
+  background-image: $nav-blue-gradient;
   padding: 80px 0 84px;
 
   @media(max-width: $phone-xlarge) {

--- a/about/index.html
+++ b/about/index.html
@@ -113,18 +113,20 @@ headline: 'About Spine'
 </section>
 
 <section class="clients-section">
-    <h2 class="section-title">Our Clients</h2>
-    <div class="d-flex flex-wrap justify-content-center">
-        <a href="https://backgroundknockout.com/" class="logo-card">
-            <img src="{{ site.baseurl }}/img/software-logos/bko.svg"
-                 title="Background Knockout"
-                 alt="Background Knockout">
-        </a>
-        <a href="https://purephotos.app/" class="logo-card">
-            <img src="{{ site.baseurl }}/img/software-logos/pure-photos.svg"
-                 title="Pure Photos"
-                 alt="Pure Photos">
-        </a>
+    <div class="container-fluid content-holder">
+        <h2 class="section-title">Our Clients</h2>
+        <div class="d-flex flex-wrap justify-content-center">
+            <a href="https://backgroundknockout.com/" class="logo-card">
+                <img src="{{ site.baseurl }}/img/software-logos/bko.svg"
+                     title="Background Knockout"
+                     alt="Background Knockout">
+            </a>
+            <a href="https://purephotos.app/" class="logo-card">
+                <img src="{{ site.baseurl }}/img/software-logos/pure-photos.svg"
+                     title="Pure Photos"
+                     alt="Pure Photos">
+            </a>
+        </div>
     </div>
 </section>
 

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -3,7 +3,7 @@ title: Privacy Statements
 headline: 'Privacy Statements'
 layout: privacy
 bodyclass: privacy-statements
-header_type: fixed-dark-header
+header_type: fixed-header
 ---
 
 <section>


### PR DESCRIPTION
This PR partially addresses #240.

This PR brings small UI changes:
- the sticky menu color was changed to blue;
- the blog post content was aligned exactly in the center;
- fixed `Our Clients` section layout on the `About` page.