### PR TITLE
Add the year period to the copyright

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -138,7 +138,7 @@
       function copyrightYear() {
           var d = new Date();
           var y = d.getFullYear();
-          document.getElementById("copyright").innerHTML = '&copy; ' + y;
+          document.getElementById("copyright").innerHTML = '&copy; 2018 – ' + y;
       }
       copyrightYear();
   </script>


### PR DESCRIPTION
This PR brings the `2018 – <current-year>` period to the copyright section in the footer.