### PR TITLE
Add top margin for arch. diagram

### DIFF
--- a/_sass/base/_diagram.scss
+++ b/_sass/base/_diagram.scss
@@ -1,3 +1,7 @@
+.diagram-box {
+  margin-top: 44px;
+}
+
 .full-screen-preview {
   .preview-header {
     padding: 24px 24px 16px;

--- a/_sass/base/_markdown.scss
+++ b/_sass/base/_markdown.scss
@@ -43,10 +43,6 @@ $article-line-height: 1.74;
     padding-top: 4px;
   }
 
-  em {
-    font-style: italic;
-  }
-
   img {
     display: block;
     width: 100%;

--- a/_sass/base/_text.scss
+++ b/_sass/base/_text.scss
@@ -109,6 +109,10 @@ strong {
   font-weight: 700;
 }
 
+em {
+  font-style: italic;
+}
+
 blockquote {
   border-left: 2px solid #eeeeee;
   padding: 0 24px 0 10px;

--- a/css/style.scss
+++ b/css/style.scss
@@ -16,7 +16,7 @@
 @import "base/_text";
 @import "base/_override";
 @import "base/_markdown";
-@import "base/_full-screen";
+@import "base/_diagram";
 
 @import "modules/_buttons";
 @import "modules/_doc-side-nav";

--- a/docs/introduction/architecture.md
+++ b/docs/introduction/architecture.md
@@ -13,17 +13,20 @@ with the server-side via `CommandService`, `QueryService`, and `SubscriptionServ
 
 The diagram below shows <span id="display-all-components">all server-side components</span>
 of a cloud application. When developing with Spine, you will be interacting
-with only <span id="display-user-facing-components">some of them</span>.
-The rest is handled by the framework.
+with only <em><span id="display-user-facing-components">some of them</span></em>, which
+are not shaded on the diagram. The rest is handled by the framework.
 
-<p>Click on a component to navigate to its definition from the [Concepts](/docs/introduction/concepts.html) page.</p>
+<p>Click on a component to navigate to its definition from
+the [Concepts](/docs/introduction/concepts.html) page.</p>
 
+<div class="diagram-box">
 {% include_relative diagrams/spine-architecture-diagram.svg %}
 
 <p class="full-screen-link">
     <a href="{{site.baseurl}}/docs/introduction/diagrams/spine-architecture-diagram-full-screen.html">
         <i class="far fa-expand"></i>
-        <span>Full screen preview</span>
+        <span>View full screen</span>
     </a>
 </p>
+</div>
 

--- a/docs/introduction/diagrams/spine-architecture-diagram-full-screen.html
+++ b/docs/introduction/diagrams/spine-architecture-diagram-full-screen.html
@@ -15,7 +15,7 @@ title: Application Architecture
             <p class="preview-subtitle">This diagram shows <span id="display-all-components">all
                 server-side components</span> of a cloud application.
                 When developing with Spine, you will be interacting with
-                <span id="display-user-facing-components">some of them</span>.</p>
+                <span id="display-user-facing-components"><em>some of them</em></span>.</p>
         </div>
     </div>
     <div class="preview-body">


### PR DESCRIPTION
This PR:

  1. Adds top margin for the architecture diagram.
  2. Adds emphasis for the “some of them” text.
  3. Adds explanation that those “some” components are not shaded on the diagram by default.
