### PR TITLE
Add `API Reference` page as `index` page

### DIFF
--- a/_data/navigation/doc_side_nav.yml
+++ b/_data/navigation/doc_side_nav.yml
@@ -38,19 +38,7 @@ doc_side_nav:
       - page: Dart
         url: /docs/client-libs/dart.html
   - page: API Reference
-    children:
-      - page: Java
-        children:
-        - page: Server
-          url: https://spine.io/core-java/reference/server/index.html
-        - page: Client
-          url: https://spine.io/core-java/reference/client/index.html
-        - page: Web Server
-          url: /docs/reference/java-web-server.html
-      - page: JavaScript Client
-        url: https://spine.io/web/reference/client-js/index.html
-      - page: Dart Client
-        url: https://spine.io/dart/reference/client/index.html
+    url: /docs/reference/
 
   - page: Examples
     url: /docs/examples/

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -14,7 +14,7 @@
             <li><p><a href="{{ site.baseurl }}/docs/introduction">Introduction</a></p></li>
             <li><p><a href="{{ site.baseurl }}/docs/quickstart-java.html">Quick Start</a></p></li>
             <li><p><a href="{{ site.baseurl }}/docs/guides/validation.html">Guides</a></p></li>
-            <li><p><a href="{{ site.baseurl }}/docs">API Reference</a></p></li>
+            <li><p><a href="{{ site.baseurl }}/docs/reference/">API Reference</a></p></li>
           </ul>
         </div>
         <hr class="footer-sections" />

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -32,7 +32,7 @@
                                 <li class="nav-item doc"><a href="{{ site.baseurl }}/docs/introduction" {% if current[2]=='introduction' %} class='nav-item-link current' {% else %} class='nav-item-link' {% endif %}><span>Introduction</span></a></li>
                                 <li class="nav-item doc"><a href="{{ site.baseurl }}/docs/quickstart-java.html" {% if current[2]=='quickstart-java.html' %}class='nav-item-link current'{% else %} class='nav-item-link' {% endif %}><span>Quick Start</span></a></li>
                                 <li class="nav-item doc"><a href="{{ site.baseurl }}/docs/guides/validation.html" {% if current[2]=='guides' %} class='nav-item-link current' {% else %} class='nav-item-link' {% endif %}><span>Guides</span></a></li>
-                                <li class="nav-item doc"><a href="{{ site.baseurl }}/docs/index.html#api-reference" {% if current[2]=='reference' %} class='nav-item-link current' {% else %} class='nav-item-link' {% endif %}><span>API Reference</span></a></li>
+                                <li class="nav-item doc"><a href="{{ site.baseurl }}/docs/reference/" {% if current[2]=='reference' %} class='nav-item-link current' {% else %} class='nav-item-link' {% endif %}><span>API Reference</span></a></li>
                                 <li class="nav-item doc"><a href="{{ site.baseurl }}/docs/examples" {% if current[2]=='examples' %} class='nav-item-link current' {% else %} class='nav-item-link' {% endif %}><span>Examples</span></a></li>
                             </ul>
                         </li>

--- a/_sass/base/_markdown.scss
+++ b/_sass/base/_markdown.scss
@@ -34,8 +34,14 @@ $article-line-height: 1.74;
     }
   }
 
-  h1 + h2 {
+  h1 + h2,
+  h1 + div + h2 {
     padding-top: 0;
+  }
+
+  ul + h2,
+  ul + div + h2 {
+    padding-top: 16px;
   }
 
   // `div` is an invisible element that is created by Anchor JS library.

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ This section provides detailed instructions on the framework use.
 ## [Client Libraries]({{ site.baseurl }}/docs/client-libs/) 
 This section provides language-specific guides for building client-side applications.
 
-## [API Reference]({{ site.baseurl }}/docs/index.html#api-reference)
+## [API Reference]({{ site.baseurl }}/docs/reference/)
 This sections provides links to the generated documentation.
 
 ## [Examples]({{ site.baseurl }}/docs/examples/)

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,25 @@
+---
+title: API Reference
+headline: Documentation
+bodyclass: docs
+layout: docs
+---
+# API Reference
+
+## Java
+
+- [Server](https://spine.io/core-java/reference/server/index.html)
+
+- [Client](https://spine.io/core-java/reference/client/index.html)
+
+- [Spine Web API](https://spine.io/web/reference/web/index.html).
+This reference defines the API for communicating with a Spine-based backend using web requests.  
+- [Implementation on Firebase](https://spine.io/web/reference/firebase-web/index.html).
+This reference is on the implementation of the Spine Web API using the Firebase Realtime Database
+to deliver data to web clients.  
+
+## JavaScript
+- [JavaScript Client](https://spine.io/web/reference/client-js/index.html)
+
+## Dart
+- [Dart Client](https://spine.io/dart/reference/client/index.html)


### PR DESCRIPTION
In this PR I have moved all the `API Reference` links from the side navigation to the separate page `/docs/reference/index.md`.