### PR TITLE
Fix the link to the Guides

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ This section gives an overview of the development process, the architecture of t
 application, information on DDD concepts implemented by the framework and how framework
 users deal with them.
 
-## [Guides]({{ site.baseurl }}/docs/guides/)
+## [Guides]({{ site.baseurl }}/docs/guides/validation/)
 This section provides detailed instructions on the framework use.
 
 ## [Client Libraries]({{ site.baseurl }}/docs/client-libs/) 

--- a/docs/introduction/naming-conventions.md
+++ b/docs/introduction/naming-conventions.md
@@ -162,9 +162,6 @@ the following reasons:
     a generated data type for holding the state of the entity.
  2. Such data structure does not represent a whole `Aggregate` or `ProcessManager` thing anyway. 
     It is just data.
-
-<p class="note">For details on aggregates usage, refer to a
-    [Defining Aggregate Guide](/docs/guides/defining-aggregate.html).</p>  
  
 ## Packages
 


### PR DESCRIPTION
This PR fixes the link to the Guides page.
And also removes the block with the link to the `Defining Aggregate Guide` page.