### PR TITLE
Add `resources` link to the mobile navigation

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -34,6 +34,7 @@
                                 <li class="nav-item doc"><a href="{{ site.baseurl }}/docs/guides/validation.html" {% if current[2]=='guides' %} class='nav-item-link current' {% else %} class='nav-item-link' {% endif %}><span>Guides</span></a></li>
                                 <li class="nav-item doc"><a href="{{ site.baseurl }}/docs/reference/" {% if current[2]=='reference' %} class='nav-item-link current' {% else %} class='nav-item-link' {% endif %}><span>API Reference</span></a></li>
                                 <li class="nav-item doc"><a href="{{ site.baseurl }}/docs/examples" {% if current[2]=='examples' %} class='nav-item-link current' {% else %} class='nav-item-link' {% endif %}><span>Examples</span></a></li>
+                                <li class="nav-item doc"><a href="{{ site.baseurl }}/docs/resources/" {% if current[2]=='resources' %} class='nav-item-link current' {% else %} class='nav-item-link' {% endif %}><span>Resources</span></a></li>
                             </ul>
                         </li>
                         <li class="nav-item"><a href="{{ site.baseurl }}/blog/" {% if current[1]=='blog' %} class='nav-item-link current' {% else %} class='nav-item-link' {% endif %}><span>Blog</span></a></li>

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,3 +29,6 @@ This sections provides links to the generated documentation.
 ## [Examples]({{ site.baseurl }}/docs/examples/)
 This page is the entry point for learning from the code of
 the [example applications](https://github.com/spine-examples/). 
+
+## [Resources]({{ site.baseurl }}/docs/resources/)
+A brief selection of learning materials we recommend to the colleagues in DDD.


### PR DESCRIPTION
This PR brings the `Resources` link to mobile navigation and to the document overview page.