### PR TITLE
Add `html-proofer` dependency to the `Gemfile.lock`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,14 @@ GEM
     html-pipeline (2.13.0)
       activesupport (>= 2)
       nokogiri (>= 1.4)
+    html-proofer (3.13.0)
+      addressable (~> 2.3)
+      mercenary (~> 0.3)
+      nokogiri (~> 1.10)
+      parallel (~> 1.3)
+      rainbow (~> 3.0)
+      typhoeus (~> 1.3)
+      yell (~> 2.0)
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
@@ -213,9 +221,11 @@ GEM
     octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
+    parallel (1.18.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (3.1.1)
+    rainbow (3.0.0)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -240,6 +250,7 @@ GEM
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
+    yell (2.2.0)
     zeitwerk (2.3.0)
 
 PLATFORMS
@@ -248,6 +259,8 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
+  html-proofer
+  jekyll
   jekyll-paginate
   rouge
 


### PR DESCRIPTION
This PR brings `html-proofer` dependency to the `Gemfile.lock`.