### PR TITLE
Add ignore rule for external GitHub links to the links checker command.

### DIFF
--- a/.github/workflows/links-check.yml
+++ b/.github/workflows/links-check.yml
@@ -24,4 +24,4 @@ jobs:
           gem install bundler
           bundle install
           jekyll build
-          htmlproofer --assume-extension ./_site
+          htmlproofer --assume-extension ./_site --url-ignore /github\.com/

--- a/README.md
+++ b/README.md
@@ -78,6 +78,6 @@ code to Markdown pages. See [this doc](_samples/README.md) for the instructions.
 We use the [html-proofer](https://github.com/gjtorikian/html-proofer) tool to test broken links.
 To start test locally you may be required to install tool Gem first:
 `bundle install` and build site `jekyll build`. After that use `htmlproofer --assume-extension ./_site --url-ignore /github\.com/` command.
-GitHub links ignored because of wrong error logging described in [this](https://github.com/gjtorikian/html-proofer/issues/226) issue.
+GitHub links are ignored because of wrong error logging described in [this](https://github.com/gjtorikian/html-proofer/issues/226) issue.
 
 Also, we have the `Links check` GitHub Action for this test. It will start on push to the repository.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ code to Markdown pages. See [this doc](_samples/README.md) for the instructions.
 
 We use the [html-proofer](https://github.com/gjtorikian/html-proofer) tool to test broken links.
 To start test locally you may be required to install tool Gem first:
-`bundle install` and build site `jekyll build`. After that use `htmlproofer --assume-extension ./_site` command.
+`bundle install` and build site `jekyll build`. After that use `htmlproofer --assume-extension ./_site --url-ignore /github\.com/` command.
+GitHub links ignored because of wrong error logging described in [this](https://github.com/gjtorikian/html-proofer/issues/226) issue.
 
 Also, we have the `Links check` GitHub Action for this test. It will start on push to the repository.


### PR DESCRIPTION
This PR brings changes to the links check task flow. 

The GitHub rejects links checks from the `html-proofer` tool. The issue is described  [here](https://github.com/gjtorikian/html-proofer/issues/226). I added ignore rule for external GitHub links to avoid wrong error messages. 