### PR TITLE
Update HTML Proofer parameters to prevent incorrect links checks

### DIFF
--- a/AUTHORING.md
+++ b/AUTHORING.md
@@ -91,9 +91,10 @@ After that, please use the following command:
 ./_script/proof-links
 ```
 
-> Please note that links to GitHub are ignored because GitHub rejects the check coming 
-> from `htmlproofer`. Details of this are described in
+> Please note that links to GitHub are ignored by `--http-status-ignore "429"` command, because GitHub rejects the check 
+> coming from `htmlproofer`. Details of this are described in
 > [this issue](https://github.com/gjtorikian/html-proofer/issues/226).
+> Also we log only 4xx errors to avoid incorrect links checks.  
 
 Also, we have a GitHub Action which tests the links when the code is pushed to GitHub. 
 Please see the [`.github/links-check.yml`](.github/links-check.yml) file for details.

--- a/_script/proof-links
+++ b/_script/proof-links
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 # Check the links used by the site.
-#  Ignore links to GitHub because it rejects the checks coming from `htmlproofer`.
-htmlproofer --assume-extension ./_site --url-ignore /github\.com/
+# Log only 4xx errors and ignore 429 http errors.
+htmlproofer htmlproofer --assume-extension ./_site --only_4xx --http-status-ignore "429"

--- a/_script/proof-links
+++ b/_script/proof-links
@@ -2,4 +2,4 @@
 
 # Check the links used by the site.
 # Log only 4xx errors and ignore 429 http errors.
-htmlproofer htmlproofer --assume-extension ./_site --only_4xx --http-status-ignore "429"
+htmlproofer --assume-extension ./_site --only_4xx --http-status-ignore "429"


### PR DESCRIPTION
This PR brings updates to the `./_script/proof-links` script. 

I updated HTML Proofer parameters to prevent errors based on unexpected http statuses:
* `429 Too Many Requests` from GitHub links;
* `301 Moved Permanently` from the [vlingo.io](https://vlingo.io/) site.    
