### PR TITLE
Add post category and change posts URL by this config

### DIFF
--- a/_posts/2018-05-21-blog-is-now-live.md
+++ b/_posts/2018-05-21-blog-is-now-live.md
@@ -4,6 +4,7 @@ title: Blog is now live
 published: true
 bodyclass: post
 header_type: fixed-header
+categories: blog
 ---
 
 As we are getting closer to `1.0-GA` release of the framework we thought that it would be nice to start blogging about the framework development, the ES/CQRS-based projects, our insights etc.

--- a/_posts/2018-05-22-migrating-to-java-8.md
+++ b/_posts/2018-05-22-migrating-to-java-8.md
@@ -4,6 +4,7 @@ title: Migrating to Java 8
 published: true
 bodyclass: post
 header_type: fixed-header
+categories: blog
 ---
 
 Starting the upcoming `0.11.0` release the minimal version of Java for Spine-based application will become Java 8. Early adopters can already see the first sights of Java 8 migration in core framework modules.

--- a/_posts/2019-08-21-spine-event-engine-1-0-is-out.md
+++ b/_posts/2019-08-21-spine-event-engine-1-0-is-out.md
@@ -4,6 +4,7 @@ title: Spine Event Engine 1.0 is Out!
 published: true
 bodyclass: post
 header_type: fixed-header
+categories: blog
 ---
 
 We are glad to announce the release of the first production-ready version of Spine Event Engine!

--- a/_posts/2020-02-08-learning-at-ddd-europe-2020.md
+++ b/_posts/2020-02-08-learning-at-ddd-europe-2020.md
@@ -4,6 +4,7 @@ title: Learning at DDD Europe 2020
 published: true
 bodyclass: post
 header_type: fixed-header
+categories: blog
 ---
 
 What a great inspiration mixing in with the global DDD-crowd is!

--- a/_posts/2020-03-02-new-guide-on-integrating-with-third-party.md
+++ b/_posts/2020-03-02-new-guide-on-integrating-with-third-party.md
@@ -5,6 +5,7 @@ published: true
 bodyclass: post
 header_type: fixed-header
 author: Dmytro Dashenkov
+categories: blog
 ---
 
 Integrating an Event-based system with third-party software or a legacy system can be tricky. 


### PR DESCRIPTION
This PR closes #337 issue. 

The post category `categories: blog` config changes post path in `_site` folder and changes URL for the post. 
This configuration should be added in every new post, if we want to have the same files structure.  

