### PR TITLE
Fix internal references

### DIFF
--- a/docs/guides/start-new-project.md
+++ b/docs/guides/start-new-project.md
@@ -234,7 +234,6 @@ Opt for smaller, fine-graded Pull Requests instead of cluttered and complicated 
 [process-manager-concept]: {{ site.baseurl }}/docs/introduction/concepts.html#process-manager "Check out the Process Manager definition"
 [signals]: {{ site.baseurl }}/docs/introduction/#getting-domain-knowledge "Learn more about Signals"
 [testing]: {{ site.baseurl }}/docs/introduction/#testing "Learn more about Testing"
-[VaughnVernon]: {{ site.baseurl }}/docs/resources/people.html#vaughn-vernon
 
 [identifier-concept]: {{ site.baseurl }}/docs/introduction/concepts.html#identifier "Learn more about Identifiers"
 [identifiers-proto]: {{ site.baseurl }}/docs/introduction/naming-conventions.html#identifiersproto "Learn more about Identifiers proto structure"
@@ -258,3 +257,4 @@ Opt for smaller, fine-graded Pull Requests instead of cluttered and complicated 
 [EventStorming]: https://eventstorming.com "Learn more about EventStorming"
 [UbiquitousLanguage]: https://martinfowler.com/bliki/UbiquitousLanguage.html "Learn more about the Ubiquitous Language"
 [ReactiveDDD]: https://www.infoq.com/presentations/reactive-ddd/ "Check out the Reactive DDD presentation"
+[VaughnVernon]: https://vaughnvernon.co/

--- a/docs/guides/start-new-project.md
+++ b/docs/guides/start-new-project.md
@@ -252,7 +252,7 @@ Opt for smaller, fine-graded Pull Requests instead of cluttered and complicated 
 
 [entities]: {{ site.baseurl }}/docs/introduction/#entities "See more examples on entities"
 [entity-concept]: {{ site.baseurl }}/docs/introduction/concepts.html#entities "Learn more about Entities"
-[entity-state-naming]: {{ site.baseurl }}/docs/introduction/naming-conventions.html#entity-states11 "Learn more about Entity states"
+[entity-state-naming]: {{ site.baseurl }}/docs/introduction/naming-conventions.html#entity-states-1 "Learn more about Entity states"
 [entity-state-proto]: {{ site.baseurl }}/docs/introduction/naming-conventions.html#entity-states "Learn more about Entity states proto structure"
 
 [EventStorming]: https://eventstorming.com "Learn more about EventStorming"

--- a/docs/guides/start-new-project.md
+++ b/docs/guides/start-new-project.md
@@ -234,7 +234,7 @@ Opt for smaller, fine-graded Pull Requests instead of cluttered and complicated 
 [process-manager-concept]: {{ site.baseurl }}/docs/introduction/concepts.html#process-manager "Check out the Process Manager definition"
 [signals]: {{ site.baseurl }}/docs/introduction/#getting-domain-knowledge "Learn more about Signals"
 [testing]: {{ site.baseurl }}/docs/introduction/#testing "Learn more about Testing"
-[VaughnVernon]: {{ site.baseurl }}/docs/people.html#vaughn-vernon
+[VaughnVernon]: {{ site.baseurl }}/docs/resources/people.html#vaughn-vernon
 
 [identifier-concept]: {{ site.baseurl }}/docs/introduction/concepts.html#identifier "Learn more about Identifiers"
 [identifiers-proto]: {{ site.baseurl }}/docs/introduction/naming-conventions.html#identifiersproto "Learn more about Identifiers proto structure"


### PR DESCRIPTION
In this PR I have fixed links to internal resources introduced in #338.

Whenever referencing a link, one should use links from the rendered header, but not the dynamic side-nav menu. Even though the dynamic link works, it never passes the build.