### PR TITLE
Add email protect

### DIFF
--- a/AUTHORING.md
+++ b/AUTHORING.md
@@ -11,6 +11,7 @@ This document is a guide for adding content to the [spine.io](https://spine.io) 
 - [Adding collapsible list for sidebar navigation](#adding-collapsible-list-for-sidebar-navigation)
 - [Adding code samples to the site](#adding-code-samples-to-the-site)
 - [Testing broken links](#testing-broken-links)
+- [Adding email links](#adding-email-links)
 
 <small><i><a href='http://ecotrust-canada.github.io/markdown-toc/'>Table of contents generated with markdown-toc</a></i></small>
 
@@ -88,3 +89,33 @@ After that, please use the following command:
 Also, we have a GitHub Action which tests the links when the pull request is created to the `master`. 
 Please see the [`.github/workflows/proof-links.yml`](.github/workflows/proof-links.yml) file for details.
 
+# Adding email links
+
+We use the [Jekyll Email Protect](https://github.com/vwochnik/jekyll-email-protect) to protect our 
+email addresses from spam bots. We store all email variables in the `_data/support.yml` file.
+
+### In HTML
+```
+<a href="mailto:{{ 'example@example.com' | encode_email }}">{{ 'example@example.com' | html_encode_email }}</a>
+```
+
+Or through a variable:
+```
+<a href="mailto:{{ site.data.support.email | encode_email }}">{{ site.data.support.email | html_encode_email }}</a>
+```
+
+The above code will yield:
+```
+<a href="%65%78%61%6D%70%6C%65@%65%78%61%6D%70%6C%65.%63%6F%6D">%65%78%61%6D%70%6C%65@%65%78%61%6D%70%6C%65.%63%6F%6D</a>
+```
+
+### In Markdown
+In markdown files we cannot obfuscate the link text, so it would be safer to use something like `Contact us`.
+```
+[{{ Contact us }}](mailto:{{ site.data.support.email | encode_email }})
+```
+
+The above code will yield 
+```
+<a href="%65%78%61%6D%70%6C%65@%65%78%61%6D%70%6C%65.%63%6F%6D">Contact us</a>
+```

--- a/AUTHORING.md
+++ b/AUTHORING.md
@@ -115,7 +115,7 @@ In markdown files we cannot obfuscate the link text, so it would be safer to use
 [{{ Contact us }}](mailto:{{ site.data.support.email | encode_email }})
 ```
 
-The above code will yield 
+The above code will yield: 
 ```
 <a href="%65%78%61%6D%70%6C%65@%65%78%61%6D%70%6C%65.%63%6F%6D">Contact us</a>
 ```

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 gem 'jekyll'
 gem 'jekyll-paginate'
 gem 'github-pages'
+gem 'jekyll-email-protect'
 gem 'rouge'
 gem 'html-proofer'
 gem 'embed-code', :git => 'https://github.com/SpineEventEngine/embed-code', :group => :jekyll_plugins

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,6 +129,7 @@ GEM
       rouge (>= 2.0, < 4.0)
     jekyll-default-layout (0.1.4)
       jekyll (~> 3.0)
+    jekyll-email-protect (1.1.0)
     jekyll-feed (0.13.0)
       jekyll (>= 3.7, < 5.0)
     jekyll-gist (1.5.0)
@@ -270,6 +271,7 @@ DEPENDENCIES
   github-pages
   html-proofer
   jekyll
+  jekyll-email-protect
   jekyll-paginate
   rouge
 

--- a/_config.yml
+++ b/_config.yml
@@ -17,7 +17,9 @@ gitter_username: SpineEventEngine
 google_analytics_tag: UA-71822190-1
 
 # Gems
-plugins: [jekyll-paginate]
+plugins:
+  - jekyll-paginate
+  - jekyll-email-protect
 
 # Conversion
 markdown:    kramdown

--- a/_posts/2018-05-21-blog-is-now-live.md
+++ b/_posts/2018-05-21-blog-is-now-live.md
@@ -14,4 +14,4 @@ The plan is to do this on a regular basis, so stay tuned.
 
 Your feedback and questions are welcome at 
 [@{{site.twitter_username}}](https://twitter.com/{{site.twitter_username}}) or 
-[{{site.data.support.email | html_encode_email}}](mailto:{{ site.data.support.email | encode_email }}).
+[{{ site.data.support.email }}](mailto:{{ site.data.support.email | encode_email }}).

--- a/_posts/2018-05-21-blog-is-now-live.md
+++ b/_posts/2018-05-21-blog-is-now-live.md
@@ -7,8 +7,11 @@ header_type: fixed-header
 categories: blog
 ---
 
-As we are getting closer to `1.0-GA` release of the framework we thought that it would be nice to start blogging about the framework development, the ES/CQRS-based projects, our insights etc.
+As we are getting closer to `1.0-GA` release of the framework we thought that it would be nice to 
+start blogging about the framework development, the ES/CQRS-based projects, our insights etc.
 
 The plan is to do this on a regular basis, so stay tuned.
 
-Your feedback and questions are welcome at <a href="https://twitter.com/{{ site.twitter_username }}" target="_blank">@SpineEngine</a> or <a href="mailto:spine-developers@teamdev.com">spine-developers@teamdev.com</a>.
+Your feedback and questions are welcome at 
+[@{{site.twitter_username}}](https://twitter.com/{{site.twitter_username}}) or 
+[{{site.data.support.email | html_encode_email}}](mailto:{{ site.data.support.email | encode_email }}).

--- a/contribute/index.html
+++ b/contribute/index.html
@@ -6,4 +6,4 @@ title: Contribute
 <!-- Example of a full width page section -->
 <h2 class="page-header">How to Contribute</h2>
 <p class="lead">To contribute to Spine Event Engine, please fork the GitHub Spine Event Repository repository.
-<p class="lead"> Email: <a href="mailto:{{ site.data.support.email }}" itemprop="email">{{ site.data.support.email }}</a></p>
+<p class="lead"> Email: <a href="mailto:{{ site.data.support.email | encode_email }}" itemprop="email">{{ site.data.support.email | html_encode_email}}</a></p>

--- a/contribute/index.html
+++ b/contribute/index.html
@@ -6,4 +6,4 @@ title: Contribute
 <!-- Example of a full width page section -->
 <h2 class="page-header">How to Contribute</h2>
 <p class="lead">To contribute to Spine Event Engine, please fork the GitHub Spine Event Repository repository.
-<p class="lead"> Email: <a href="mailto:{{ site.data.support.email | encode_email }}" itemprop="email">{{ site.data.support.email | html_encode_email}}</a></p>
+<p class="lead"> Email: <a href="mailto:{{ site.data.support.email | encode_email }}">{{ site.data.support.email | html_encode_email }}</a></p>


### PR DESCRIPTION
This PR brings a [Jekyll Email Protect](https://github.com/vwochnik/jekyll-email-protect) plugin to protect our emails from spam bots.

## Usage
#### In HTML
```
<a href="mailto:{{ 'example@example.com' | encode_email }}">{{ 'example@example.com' | html_encode_email }}</a>
```
Or through a variable:
```
<a href="mailto:{{ site.data.support.email | encode_email }}">{{ site.data.support.email | html_encode_email }}</a>
```

#### In Markdown
```
[{{ Contact us }}](mailto:{{ site.data.support.email | encode_email }})
```