### PR TITLE
Add Airport example, and article links

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -4,18 +4,24 @@ headline: 'Spine Examples'
 bodyclass: 'docs'
 layout: docs
 ---
-<p class="lead">Examples are available through the <a target="_blank" href="https://github.com/spine-examples">Spine Examples</a> GitHub organization.  
-If&nbsp;you&nbsp;want&nbsp;to see a bigger picture of a Spine-based application, have a look at the
-<a target="_blank" href="https://github.com/SpineEventEngine/todo-list">ToDo List</a> example. 
-Links to smaller examples are listed below.
-</p>
+<p class="lead">Examples are available through the <a target="_blank" href="https://github.com/spine-examples">Spine Examples</a> GitHub organization.</p>
+
+<p>Please see the selected list of the examples with the descriptions below.</p>
 
 ## Java
 <ul>
-    <li><a target="_blank" href="https://github.com/spine-examples/hello">Hello World</a> — a minimal client-server app.</li>
-    <li><a target="_blank" href="https://github.com/spine-examples/blog">Blog</a> — shows server-side functionality of a simple blog.</li>
-    <li><a target="_blank" href="https://github.com/spine-examples/kanban">Kanban</a> — demonstrates how to orchestrate work of Aggregates using Process Managers.</li>
-    <li><a target="_blank" href="https://github.com/spine-examples/todo-list">ToDo List</a> — ToDo List service with multiple client applications.</li>
+    <li><a target="_blank" href="https://github.com/spine-examples/hello">Hello World</a>
+     — a minimal client-server solution described in the <a href="{{site.baseurl}}/docs/quick-start/index.html">“Quick Start”</a> guide.</li>
+    <li><a target="_blank" href="https://github.com/spine-examples/blog">Blog</a>
+     — shows server-side functionality of a simple blog.</li>
+    <li><a target="_blank" href="https://github.com/spine-examples/kanban">Kanban</a>
+     — shows orchestrating Aggregates using Process Managers.</li>
+    <li><a target="_blank" href="https://github.com/spine-examples/airport">Airport</a>
+     — integrating a third-party systems using a Bounded Context.
+       This example accompanies the <a href="{{site.baseurl}}/docs/guides/integration.html">“Integration with a Third Party”</a> guide.</li>
+    <li><a target="_blank" href="https://github.com/spine-examples/todo-list">ToDo List</a>
+     — a simple task management system with multiple client applications. If&nbsp;you&nbsp;want&nbsp;to see
+      a bigger picture of a Spine-based solution, have a look at this example.</li>
 </ul>
 
 ## JavaScript


### PR DESCRIPTION
This PR improves the Examples page by:
  * adding the Airport example;
  * adding links to the guides corresponding to the examples.
