### PR TITLE
Fix the architecture diagram SVG

### DIFF
--- a/docs/introduction/diagrams/spine-architecture-diagram.svg
+++ b/docs/introduction/diagrams/spine-architecture-diagram.svg
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <svg  viewBox="0 0 1463 1263" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <title>diagram-content</title>
     <defs>


### PR DESCRIPTION
This PR removes the `<?xml?>` line from the SVG file to fix it displaying on UI.

Please see #359 for details.