### PR TITLE
Link documentation pages using “Prev”/“Next” buttons

### DIFF
--- a/AUTHORING.md
+++ b/AUTHORING.md
@@ -12,6 +12,7 @@ This document is a guide for adding content to the [spine.io](https://spine.io) 
 - [Adding code samples to the site](#adding-code-samples-to-the-site)
 - [Testing broken links](#testing-broken-links)
 - [Adding email links](#adding-email-links)
+- [Managing the “Prev”/“Next” buttons in the documentation](#managing-the--prev---next--buttons-in-the-documentation)
 
 <small><i><a href='http://ecotrust-canada.github.io/markdown-toc/'>Table of contents generated with markdown-toc</a></i></small>
 
@@ -119,3 +120,50 @@ The above code will yield:
 ```
 <a href="%65%78%61%6D%70%6C%65@%65%78%61%6D%70%6C%65.%63%6F%6D">Contact us</a>
 ```
+
+# Managing the “Prev”/“Next” buttons in the documentation
+
+The “Prev”/“Next” buttons are generated automatically for all document pages. The generation is 
+based on the [`doc_side_nav.yml`](_data/navigation/doc_side_nav.yml) navigation.
+
+To customize the automatically added “Prev”/“Next” buttons, add the appropriate variables to 
+the **front matter** block of the document page.
+
+### To hide the “Previous” or “Next” button:
+
+```
+prev_btn: false
+```
+
+```
+next_btn: false
+```
+
+### To customize the “Previous” or “Next” button name:
+```
+prev_btn: 
+  page: Development Process Overview
+```
+
+```
+next_btn: 
+  page: Development Process Overview
+```
+
+### To customize the “Previous” or “Next” button name and URL:
+```
+prev_btn: 
+  page: Development Process Overview
+  url: /docs/introduction/
+```
+
+```
+next_btn: 
+  page: Architecture Overview
+  url: /docs/introduction/architecture.html
+```
+
+**Related files:**
+- `_includes/doc-next-prev-nav.html` - the navigation template with the automatic button generation;
+- `_sass/modules/_doc-next-prev-nav.scss` - navigation styles;
+- `_layouts/docs.html` - the documentation layout where the `doc-next-prev-nav` is included.

--- a/AUTHORING.md
+++ b/AUTHORING.md
@@ -12,7 +12,7 @@ This document is a guide for adding content to the [spine.io](https://spine.io) 
 - [Adding code samples to the site](#adding-code-samples-to-the-site)
 - [Testing broken links](#testing-broken-links)
 - [Adding email links](#adding-email-links)
-- [Managing the “Prev”/“Next” buttons in the documentation](#managing-the--prev---next--buttons-in-the-documentation)
+- [Managing the “Prev”/“Next” buttons in the documentation](#managing-the-prevnext-buttons-in-the-documentation)
 
 <small><i><a href='http://ecotrust-canada.github.io/markdown-toc/'>Table of contents generated with markdown-toc</a></i></small>
 

--- a/AUTHORING.md
+++ b/AUTHORING.md
@@ -6,8 +6,8 @@ This document is a guide for adding content to the [spine.io](https://spine.io) 
 - [Using URLs in Markdown](#using-urls-in-markdown)
     + [Links to Blog Posts](#links-to-blog-posts)
       - [Rule 1 -- Always concatenate Jekyll and Liquid tags](#rule-1----always-concatenate-jekyll-and-liquid-tags)
-      - [Rule 2 -- *(Almost)* Always start links with `{{ site.baseurl }}`](#rule-2------almost---always-start-links-with-----sitebaseurl----)
-      - [Rule 3 -- Always use a trailing slash after `{{ site.baseurl }}`](#rule-3----always-use-a-trailing-slash-after-----sitebaseurl----)
+      - [Rule 2 -- *(Almost)* Always start links with `{{ site.baseurl }}`](#rule-2----almost-always-start-links-with--sitebaseurl-)
+      - [Rule 3 -- Always use a trailing slash after `{{ site.baseurl }}`](#rule-3----always-use-a-trailing-slash-after--sitebaseurl-)
 - [Adding collapsible list for sidebar navigation](#adding-collapsible-list-for-sidebar-navigation)
 - [Adding code samples to the site](#adding-code-samples-to-the-site)
 - [Testing broken links](#testing-broken-links)
@@ -61,7 +61,7 @@ For instructions on adding or changing sidebar navigation, please see the [Navig
 
 # Adding code samples to the site
 
-Please see [this document](_code/README.md) for the instructions.
+Please see [this document](_code/EMBEDDING.md) for the instructions.
 
 # Testing broken links
 

--- a/_includes/doc-next-prev-nav.html
+++ b/_includes/doc-next-prev-nav.html
@@ -18,6 +18,8 @@
   ~ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   -->
 
+<!-- The `navigation_list` array contains all pages from the `_data/navigation/doc_side_nav.yml`
+file that have internal URLs. All pages are in the right order. -->
 {% assign navigation_list = "" | split: ',' %}
 {% for item in site.data.navigation.doc_side_nav.doc_side_nav %}
     {% if item.url %}

--- a/_includes/doc-next-prev-nav.html
+++ b/_includes/doc-next-prev-nav.html
@@ -51,11 +51,11 @@
                         {% if page.prev_link != false %}
                             {% if page.prev_link %}
                                 <a class="link-back" href="{{ page.prev_link.url }}">
-                                    <span>{{ page.prev_link.page }}</span>
+                                    {{ page.prev_link.page }}
                                 </a>
                             {% else %}
                                 <a class="link-back" href="{{ prev.url }}">
-                                    <span>{{ prev.page }}</span>
+                                    {{ prev.page }}
                                 </a>
                             {% endif %}
                         {% endif %}
@@ -67,11 +67,11 @@
                         {% if page.next_link != false %}
                             {% if page.next_link %}
                                 <a class="link-next" href="{{ page.next_link.url }}">
-                                    <span>{{ page.next_link.page }}</span>
+                                    {{ page.next_link.page }}
                                 </a>
                             {% else %}
                                 <a class="link-next" href="{{ next.url }}">
-                                    <span>{{ next.page }}</span>
+                                    {{ next.page }}
                                 </a>
                             {% endif %}
                         {% endif %}

--- a/_includes/doc-next-prev-nav.html
+++ b/_includes/doc-next-prev-nav.html
@@ -50,10 +50,10 @@ file that have internal URLs. All pages are in the right order. -->
             {% if nav_item.url == page.url %}
                 {% unless forloop.first %}
                     <li class="previous">
-                        {% if page.prev_link != false %}
-                            {% if page.prev_link %}
-                                <a class="link-back" href="{% if page.prev_link.url %}{{ page.prev_link.url }}{% else %}{{ prev.url }}{% endif %}">
-                                    {{ page.prev_link.page }}
+                        {% if page.prev_btn != false %}
+                            {% if page.prev_btn %}
+                                <a class="link-back" href="{% if page.prev_btn.url %}{{ page.prev_btn.url }}{% else %}{{ prev.url }}{% endif %}">
+                                    {{ page.prev_btn.page }}
                                 </a>
                             {% else %}
                                 <a class="link-back" href="{{ prev.url }}">
@@ -66,10 +66,10 @@ file that have internal URLs. All pages are in the right order. -->
                 {% unless forloop.last %}
                     {% assign next = navigation_list[forloop.index] %}
                     <li class="next">
-                        {% if page.next_link != false %}
-                            {% if page.next_link %}
-                                <a class="link-next" href="{% if page.next_link.url %}{{ page.next_link.url }}{% else %}{{ next.url }}{% endif %}">
-                                    {{ page.next_link.page }}
+                        {% if page.next_btn != false %}
+                            {% if page.next_btn %}
+                                <a class="link-next" href="{% if page.next_btn.url %}{{ page.next_btn.url }}{% else %}{{ next.url }}{% endif %}">
+                                    {{ page.next_btn.page }}
                                 </a>
                             {% else %}
                                 <a class="link-next" href="{{ next.url }}">

--- a/_includes/doc-next-prev-nav.html
+++ b/_includes/doc-next-prev-nav.html
@@ -49,9 +49,15 @@
                 {% unless forloop.first %}
                     <li class="previous">
                         {% if page.prev_link != false %}
-                            <a class="link-back" href="{{ prev.url }}">
-                                <span>{{ prev.page }}</span>
-                            </a>
+                            {% if page.prev_link %}
+                                <a class="link-back" href="{{ page.prev_link.url }}">
+                                    <span>{{ page.prev_link.page }}</span>
+                                </a>
+                            {% else %}
+                                <a class="link-back" href="{{ prev.url }}">
+                                    <span>{{ prev.page }}</span>
+                                </a>
+                            {% endif %}
                         {% endif %}
                     </li>
                 {% endunless %}
@@ -59,9 +65,15 @@
                     {% assign next = navigation_list[forloop.index] %}
                     <li class="next">
                         {% if page.next_link != false %}
-                            <a class="link-next" href="{{ next.url }}">
-                                <span>{{ next.page }}</span>
-                            </a>
+                            {% if page.next_link %}
+                                <a class="link-next" href="{{ page.next_link.url }}">
+                                    <span>{{ page.next_link.page }}</span>
+                                </a>
+                            {% else %}
+                                <a class="link-next" href="{{ next.url }}">
+                                    <span>{{ next.page }}</span>
+                                </a>
+                            {% endif %}
                         {% endif %}
                     </li>
                 {% endunless %}

--- a/_includes/doc-next-prev-nav.html
+++ b/_includes/doc-next-prev-nav.html
@@ -1,0 +1,72 @@
+<!--
+  ~ Copyright 2020, TeamDev. All rights reserved.
+  ~
+  ~ Redistribution and use in source and/or binary forms, with or without
+  ~ modification, must retain the above copyright notice and the following
+  ~ disclaimer.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  ~ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  ~ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  ~ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  ~ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  ~ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  ~ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  ~ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  ~ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  ~ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  ~ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
+{% assign navigation_list = "" | split: ',' %}
+{% for item in site.data.navigation.doc_side_nav.doc_side_nav %}
+    {% if item.url %}
+        {% assign navigation_list = navigation_list | push: item %}
+    {% endif %}
+    {% if item.children[0] %}
+        {% for entry in item.children %}
+            {% if entry.url %}
+                {% assign navigation_list = navigation_list | push: entry %}
+            {% endif %}
+            {% if entry.children[0] %}
+                {% for subentry in entry.children %}
+                    {% if subentry.url %}
+                        {% if subentry.url contains '://' %}
+                            {% else %}
+                                {% assign navigation_list = navigation_list | push: subentry %}
+                        {% endif %}
+                    {% endif %}
+                {% endfor %}
+            {% endif %}
+        {% endfor %}
+    {% endif %}
+{% endfor %}
+
+<div class="next-prev-nav">
+    <ul>
+        {% for nav_item in navigation_list %}
+            {% if nav_item.url == page.url %}
+                {% unless forloop.first %}
+                    <li class="previous">
+                        {% if page.prev_link != false %}
+                            <a class="link-back" href="{{ prev.url }}">
+                                <span>{{ prev.page }}</span>
+                            </a>
+                        {% endif %}
+                    </li>
+                {% endunless %}
+                {% unless forloop.last %}
+                    {% assign next = navigation_list[forloop.index] %}
+                    <li class="next">
+                        {% if page.next_link != false %}
+                            <a class="link-next" href="{{ next.url }}">
+                                <span>{{ next.page }}</span>
+                            </a>
+                        {% endif %}
+                    </li>
+                {% endunless %}
+            {% endif %}
+            {% assign prev = nav_item %}
+        {% endfor %}
+    </ul>
+</div>

--- a/_includes/doc-next-prev-nav.html
+++ b/_includes/doc-next-prev-nav.html
@@ -52,7 +52,7 @@ file that have internal URLs. All pages are in the right order. -->
                     <li class="previous">
                         {% if page.prev_link != false %}
                             {% if page.prev_link %}
-                                <a class="link-back" href="{{ page.prev_link.url }}">
+                                <a class="link-back" href="{% if page.prev_link.url %}{{ page.prev_link.url }}{% else %}{{ prev.url }}{% endif %}">
                                     {{ page.prev_link.page }}
                                 </a>
                             {% else %}
@@ -68,7 +68,7 @@ file that have internal URLs. All pages are in the right order. -->
                     <li class="next">
                         {% if page.next_link != false %}
                             {% if page.next_link %}
-                                <a class="link-next" href="{{ page.next_link.url }}">
+                                <a class="link-next" href="{% if page.next_link.url %}{{ page.next_link.url }}{% else %}{{ next.url }}{% endif %}">
                                     {{ page.next_link.page }}
                                 </a>
                             {% else %}

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -17,6 +17,7 @@ bodyclass: docs
         </div>
         <div class="col-12 col-lg article-container markdown">
             {{ content }}
+            {% include doc-next-prev-nav.html %}
         </div>
         <div class="col-lg toc-col">
             <div id="toc" class="toc sticky-element"></div>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -16,8 +16,12 @@ bodyclass: docs
             {% include doc-side-nav.html %}
         </div>
         <div class="col-12 col-lg article-container markdown">
-            {{ content }}
-            {% include doc-next-prev-nav.html %}
+            <div class="content-container">
+                {{ content }}
+            </div>
+            <div class="bottom-nav">
+                {% include doc-next-prev-nav.html %}
+            </div>
         </div>
         <div class="col-lg toc-col">
             <div id="toc" class="toc sticky-element"></div>

--- a/_sass/base/_common.scss
+++ b/_sass/base/_common.scss
@@ -212,7 +212,7 @@ $tooltip-padding: .25rem .65rem;
 }
 
 $article-container-border: 1px solid $article-border-color;
-$article-container-padding: 32px 56px 48px;
+$article-container-padding: 32px 56px 40px;
 $article-container-padding-mobile: 0 15px;
 $article-container-margin-bottom: 32px;
 $article-container-border-radius: $border-radius;

--- a/_sass/base/_common.scss
+++ b/_sass/base/_common.scss
@@ -212,7 +212,7 @@ $tooltip-padding: .25rem .65rem;
 }
 
 $article-container-border: 1px solid $article-border-color;
-$article-container-padding: 32px 56px 56px;
+$article-container-padding: 32px 56px 48px;
 $article-container-padding-mobile: 0 15px;
 $article-container-margin-bottom: 32px;
 $article-container-border-radius: $border-radius;

--- a/_sass/modules/_doc-next-prev-nav.scss
+++ b/_sass/modules/_doc-next-prev-nav.scss
@@ -1,0 +1,44 @@
+/*!
+ * Copyright 2020, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+.next-prev-nav {
+  margin-top: 48px;
+
+  ul {
+    list-style: none;
+    margin: 0;
+
+    li {
+      display: inline-block;
+      width: 49%;
+      margin: 0;
+
+      &.next {
+        float: right;
+        text-align: right;
+      }
+
+      span {
+        font-family: $main-font;
+        font-size: $font-size--primary;
+      }
+    }
+  }
+}

--- a/_sass/modules/_doc-next-prev-nav.scss
+++ b/_sass/modules/_doc-next-prev-nav.scss
@@ -22,21 +22,29 @@
   margin-top: 48px;
 
   ul {
+    display: flex;
     list-style: none;
     margin: 0;
 
+    $padding-between: 8px;
     li {
-      display: inline-block;
-      width: 45%;
+      flex: 1 1 auto;
+      width: 50%;
       margin: 0;
       padding: 0;
 
+      &.previous {
+        padding-right: $padding-between;
+      }
+
       &.next {
+        padding-left: $padding-between;
         float: right;
         text-align: right;
       }
 
       $arrow-icon-offset: $icon-size--s;
+      $arrow-icon-offset-mobile: 20px;
       a {
         position: relative;
         display: block;
@@ -52,10 +60,18 @@
 
         &.link-next {
           padding-right: $arrow-icon-offset;
+
+          @media (max-width: $phone-large) {
+            padding-right: $arrow-icon-offset-mobile;
+          }
         }
 
         &.link-back {
           padding-left: $arrow-icon-offset;
+
+          @media (max-width: $phone-large) {
+            padding-left: $arrow-icon-offset-mobile;
+          }
         }
 
         &:after, &:before {

--- a/_sass/modules/_doc-next-prev-nav.scss
+++ b/_sass/modules/_doc-next-prev-nav.scss
@@ -27,17 +27,49 @@
 
     li {
       display: inline-block;
-      width: 49%;
+      width: 45%;
       margin: 0;
+      padding: 0;
 
       &.next {
         float: right;
         text-align: right;
       }
 
-      span {
+      $arrow-icon-offset: $icon-size--s;
+      a {
+        position: relative;
+        display: block;
         font-family: $main-font;
         font-size: $font-size--primary;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        overflow: hidden;
+
+        &:hover {
+          text-decoration: underline;
+        }
+
+        &.link-next {
+          padding-right: $arrow-icon-offset;
+        }
+
+        &.link-back {
+          padding-left: $arrow-icon-offset;
+        }
+
+        &:after, &:before {
+          position: absolute;
+          top: 12px;
+        }
+
+        &:after {
+          right: 3px;
+        }
+
+        &:before {
+          left: 3px;
+        }
       }
     }
   }

--- a/_sass/pages/_docs.scss
+++ b/_sass/pages/_docs.scss
@@ -33,6 +33,20 @@
     }
   }
 
+  .article-container {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+
+    .content-container {
+      flex-grow: 1;
+    }
+
+    .bottom-nav {
+      flex-shrink: 0;
+    }
+  }
+
 
   $card-bottom-space: 24px;
   $card-height: calc(100% - #{$card-bottom-space});

--- a/css/style.scss
+++ b/css/style.scss
@@ -27,6 +27,7 @@
 @import "modules/_hero";
 @import "modules/_nav";
 @import "modules/_nav-search";
+@import "modules/_doc-next-prev-nav";
 @import "modules/_cookies";
 @import "modules/_feature-cards";
 @import "modules/_loader";

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ title: Documentation
 headline: Documentation
 bodyclass: docs
 layout: docs
-next_link: false
+next_btn: false
 ---
 # Welcome
 <p class="lead">Welcome to the Spine developer documentation. This page gives the overview of

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,7 @@ title: Documentation
 headline: Documentation
 bodyclass: docs
 layout: docs
+next_link: false
 ---
 # Welcome
 <p class="lead">Welcome to the Spine developer documentation. This page gives the overview of

--- a/docs/quick-start/index.md
+++ b/docs/quick-start/index.md
@@ -3,6 +3,9 @@ title: Getting Started in Java
 headline: Documentation
 bodyclass: docs
 layout: docs
+next_link: 
+  page: Development Process Overview
+  url: /docs/introduction/
 ---
 
 [//]: <> (The base path for code samples is `_samples/examples/src/main/`.)

--- a/docs/quick-start/index.md
+++ b/docs/quick-start/index.md
@@ -994,10 +994,6 @@ like events that reflect the changes of the model.
 
 Once handling of all commands and events of the selected Bounded Context is done, another
 context is selected for the development. The process is repeated until all the contexts
-are implemented.
-
-<br/>
-   
-[Next: Development Process Overview]({{site.baseurl}}/docs/introduction/index.html) 
+are implemented. 
 
 [proto3-guide]: https://developers.google.com/protocol-buffers/docs/proto3

--- a/docs/quick-start/index.md
+++ b/docs/quick-start/index.md
@@ -3,7 +3,7 @@ title: Getting Started in Java
 headline: Documentation
 bodyclass: docs
 layout: docs
-next_link: 
+next_btn: 
   page: Development Process Overview
 ---
 

--- a/docs/quick-start/index.md
+++ b/docs/quick-start/index.md
@@ -5,7 +5,6 @@ bodyclass: docs
 layout: docs
 next_link: 
   page: Development Process Overview
-  url: /docs/introduction/
 ---
 
 [//]: <> (The base path for code samples is `_samples/examples/src/main/`.)


### PR DESCRIPTION
This PR closes #356. 

This PR provides an automatic generation of the “Prev”/“Next” buttons for all document pages.
The logic is based on the navigation `doc_side_nav.yml`.

Also added the ability to customize these buttons if we need to hide them or add our own name or URL.
The instruction added to the `AUTHORING.md` file.