### PR TITLE
Remove redundant links in FAQ item

### DIFF
--- a/faq/index.html
+++ b/faq/index.html
@@ -25,10 +25,7 @@ headline: 'Frequently Asked Questions'
                         <div class="faq-content-wrapper markdown">
                             <p>We want to give our users a framework that provides an infrastructure
                                 and connects the “service” parts of applications with their “brains”,
-                                or in other words, business logic. Find out how
-                                <a href="{{ site.baseurl }}/docs/introduction/prior-art.html">industry trends</a>
-                                <a href="{{ site.baseurl }}/docs/introduction/index.html">inspired us</a>
-                                to create Spine.</p>
+                                or in other words, business logic.</p>
                         </div>
                     </div>
                 </li>


### PR DESCRIPTION
This PR simplifies the FAQ item on the framework name.
