### PR TITLE
Update Quick Start guide to use latest Bootstrap plugin

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="FrameworkDetectionExcludesConfiguration">
+    <file type="web" url="file://$PROJECT_DIR$" />
+  </component>
   <component name="JavaScriptSettings">
     <option name="languageLevel" value="ES6" />
   </component>
@@ -35,5 +38,5 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK" />
 </project>

--- a/docs/guides/gradle.md
+++ b/docs/guides/gradle.md
@@ -20,7 +20,7 @@ The minimal Gradle configuration you will need to start a new project is:
 <embed-code file="examples/hello/build.gradle" start="plugins" end="}"></embed-code>
 ```groovy
 plugins {
-    id 'io.spine.tools.gradle.bootstrap' version '1.5.27'
+    id 'io.spine.tools.gradle.bootstrap' version '1.5.29'
 }
 ```
 

--- a/docs/quick-start/index.md
+++ b/docs/quick-start/index.md
@@ -161,17 +161,15 @@ Client-side applications or modules should call: `spine.enableJava().client()`.
 The rest of the `build.gradle` file does the following:
  1. Sets the version of Java to 8.
 
- 2. Adds JUnit dependencies by applying the `tests.gradle` script plugin. 
-    
-    <p class="note">We chose to extract this and previous scripts into separate files to simplify
-     the code of `build.gradle`.</p>
+ 2. Adds JUnit dependencies by applying the `tests.gradle` script plugin (which we extracted
+    for the sake of simplicity). 
     
  3. Defines the `sayHello` task which runs the `Example` application, which orchestrates
     the demo.  
 
 We are not reviewing these parts of the project configuration deeper because they are not
 related to the use of the Spine framework. If you're interested in more details, please look into
-the code of these scripts.
+the mentioned `.gradle` files.
 
 Now, let's look into the data structure of the Hello context. 
  

--- a/docs/quick-start/index.md
+++ b/docs/quick-start/index.md
@@ -161,20 +161,12 @@ Client-side applications or modules should call: `spine.enableJava().client()`.
 The rest of the `build.gradle` file does the following:
  1. Sets the version of Java to 8.
 
- 2. Adds `generated` code directories to IntelliJ IDEA module by applying the `idea.gradle`
-    script plugin. 
-    
-    <p class="note">The framework does not depend on IDEA or its Gradle plugin.
-    We added this code because we use this IDE for development.
-    If you use it too, you may want look into `idea.gradle` to configure your Spine-based 
-    projects similarly.</p>
-    
- 3. Adds JUnit dependencies by applying the `tests.gradle` script plugin. 
+ 2. Adds JUnit dependencies by applying the `tests.gradle` script plugin. 
     
     <p class="note">We chose to extract this and previous scripts into separate files to simplify
      the code of `build.gradle`.</p>
     
- 4. Defines the `sayHello` task which runs the `Example` application, which orchestrates
+ 3. Defines the `sayHello` task which runs the `Example` application, which orchestrates
     the demo.  
 
 We are not reviewing these parts of the project configuration deeper because they are not

--- a/docs/quick-start/index.md
+++ b/docs/quick-start/index.md
@@ -136,7 +136,7 @@ adding Spine dependencies to a project is the Bootstrap plugin:
             end="^}"></embed-code>
 ```groovy
 plugins {
-    id 'io.spine.tools.gradle.bootstrap' version '1.5.27'
+    id 'io.spine.tools.gradle.bootstrap' version '1.5.29'
 }
 ```
 


### PR DESCRIPTION
This PR updates the text of the Quick Start guide to reflect the changes made in the Hello World example application, which was migrated to the 1.5.29 version of the Spine Bootstrap plugin.

IDEA Gradle plugin configuration is now done automatically and no manual work is required from the framework user.
