### PR TITLE
Update list of DDD resources

### DIFF
--- a/docs/resources/sites.md
+++ b/docs/resources/sites.md
@@ -17,3 +17,6 @@ DDD section on one of the leading media on software development.
 
 - [Awesome Domain-Driven Design](https://github.com/heynickc/awesome-ddd).
 An extensive curated list of DDD, CQRS, Event Sourcing, and EventStorming resources.
+
+- [Learning DDD](https://emacsway.github.io/ru/self-learning-for-software-engineer/#ddd).
+A selection of learning materials for gradual immersion into the topic: from the basics to the specific design cases.


### PR DESCRIPTION
Add a link to "Learning DDD" to the Sites section of DDD Resources.