### PR TITLE
Simplify title for the index page

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -6,7 +6,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="title" content="{{ site.title }} open-source CQRS/ES framework">
   <meta name="description" content="Open-source CQRS/ES framework for modern cloud applications">
-  <title>Spine / {{ page.title }}</title>
+  {% if page.index_page_title %}
+    <title>{{ page.index_page_title }}</title>
+  {% else %}
+    <title>Spine / {{ page.title }}</title>
+  {% endif %}
 
   <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 ---
 layout: landing
-title: Spine Event Engine
+index_page_title: Spine Event Engine
 bodyclass: promo-page
 ---
 


### PR DESCRIPTION
This PR replaces the `Spine / Spine Event Engine` title with the `Spine Event Engine` for the home page.