### PR TITLE
Fix checkboxes when hitting the `back` button

### DIFF
--- a/_includes/getting-help/service-section.html
+++ b/_includes/getting-help/service-section.html
@@ -109,13 +109,19 @@
                         <label class="checkbox-container" for="privacyConsent">
                             <span class="text">I agree to processing of my personal information as per
                                 <a href="{{ site.baseurl }}/privacy-statement">Privacy&nbsp;Statement</a>.</span>
-                            <input type="checkbox" class="consent" id="privacyConsent">
+                            <input type="checkbox"
+                                   class="consent"
+                                   id="privacyConsent"
+                                   autocomplete='off'>
                             <span class="checkmark"></span>
                         </label>
                         <label class="checkbox-container" for="supportAgreementConsent">
                             <span class="text">I agree to the terms of
                                 <a href="{{ site.baseurl }}/development-support-agreement">Development Support Agreement</a>.</span>
-                            <input type="checkbox" class="consent" id="supportAgreementConsent">
+                            <input type="checkbox"
+                                   class="consent"
+                                   id="supportAgreementConsent"
+                                   autocomplete='off'>
                             <span class="checkmark"></span>
                         </label>
                     </div>

--- a/_includes/getting-help/service-section.html
+++ b/_includes/getting-help/service-section.html
@@ -108,7 +108,9 @@
                     <div class="checkboxes-list">
                         <label class="checkbox-container" for="privacyConsent">
                             <span class="text">I agree to processing of my personal information as per
-                                <a href="{{ site.baseurl }}/privacy-statement">Privacy&nbsp;Statement</a>.</span>
+                                <a href="{{ site.baseurl }}/privacy-statement"
+                                   class="external"
+                                   target="_blank">Privacy&nbsp;Statement</a>.</span>
                             <input type="checkbox"
                                    class="consent"
                                    id="privacyConsent"
@@ -117,7 +119,9 @@
                         </label>
                         <label class="checkbox-container" for="supportAgreementConsent">
                             <span class="text">I agree to the terms of
-                                <a href="{{ site.baseurl }}/development-support-agreement">Development Support Agreement</a>.</span>
+                                <a href="{{ site.baseurl }}/development-support-agreement"
+                                   class="external"
+                                   target="_blank">Development Support Agreement</a>.</span>
                             <input type="checkbox"
                                    class="consent"
                                    id="supportAgreementConsent"


### PR DESCRIPTION
This PR fixes the situation when checkboxes are still checked but the button is disabled when hitting the `back` button.
Also, open the privacy pages in the new browser tab to avoid misunderstanding how to back to the page.