### PR TITLE
Fix the `Release Notes` layout that was broken by the `pre` element

### DIFF
--- a/_layouts/release-notes.html
+++ b/_layouts/release-notes.html
@@ -16,7 +16,7 @@ bodyclass: docs
                 {% include {{ page.sidenav }} %}
             {% endif %}
         </div>
-        <div class="col-12 col-lg">
+        <div class="col-12 col-lg release-notes-content-col">
             <div class="article-container markdown">
                 {% if page.date != null %}
                     <p class="date">Posted on {{ page.date | date: '%B %d, %Y' }}</p>

--- a/_sass/base/_common.scss
+++ b/_sass/base/_common.scss
@@ -54,7 +54,8 @@
 }
 
 .toc-col {
-  @media (max-width: $desktop-small) {
+  // Custom width is used here to have the central content column more readable.
+  @media (max-width: 1140px) {
     display: none;
   }
 }

--- a/_sass/pages/_release-notes.scss
+++ b/_sass/pages/_release-notes.scss
@@ -1,4 +1,9 @@
 .release-notes {
+  .release-notes-content-col {
+    // Fix the `pre` element that is inside `ul` or `ol` list and breaks the flex layout width.
+    min-width: 0;
+  }
+
   .article-container {
     margin-bottom: 16px;
     min-height: 350px;


### PR DESCRIPTION
This PR closes #396.

This PR fixes the flex column width that was broken by the `pre` element on screens between `992px` and `1258px`.