### PR TITLE
Update 2checkout order link

### DIFF
--- a/_data/payment_config.yml
+++ b/_data/payment_config.yml
@@ -1,4 +1,4 @@
-orderUrl: https://secure.2checkout.com/checkout/buy?merchant=999999999589&currency=EUR&tpl=default&prod=4HJME1JJDF&qty=1
+orderUrl: https://secure.2checkout.com/checkout/buy?
 prodApiUrl: https://us-central1-spine-site-server.cloudfunctions.net/paymentTransaction
 devApiUrl: http://localhost:5002/spine-site-server/us-central1/paymentTransaction
 reCaptchaSiteKey: 6Lef7b0ZAAAAAHPIbf6XQIzzeyCoSzS56GTej1c0

--- a/_data/payment_config.yml
+++ b/_data/payment_config.yml
@@ -1,4 +1,4 @@
-orderUrl: https://secure.2checkout.com/order/checkout.php?PRODS=31007663&QTY=1&CART=1&CARD=1&SHORT_FORM=1&CURRENCY=EUR
+orderUrl: https://secure.2checkout.com/checkout/buy?merchant=999999999589&currency=EUR&tpl=default&prod=4HJME1JJDF&qty=1
 prodApiUrl: https://us-central1-spine-site-server.cloudfunctions.net/paymentTransaction
 devApiUrl: http://localhost:5002/spine-site-server/us-central1/paymentTransaction
 reCaptchaSiteKey: 6Lef7b0ZAAAAAHPIbf6XQIzzeyCoSzS56GTej1c0

--- a/_data/payment_config.yml
+++ b/_data/payment_config.yml
@@ -1,4 +1,4 @@
-orderUrl: https://secure.2checkout.com/checkout/buy?
+orderUrl: https://secure.2checkout.com/checkout/buy?merchant=999999999589&currency=EUR&tpl=default&prod=4HJME1JJDF&qty=1
 prodApiUrl: https://us-central1-spine-site-server.cloudfunctions.net/paymentTransaction
 devApiUrl: http://localhost:5002/spine-site-server/us-central1/paymentTransaction
 reCaptchaSiteKey: 6Lef7b0ZAAAAAHPIbf6XQIzzeyCoSzS56GTej1c0

--- a/js/pricing.js
+++ b/js/pricing.js
@@ -59,6 +59,7 @@
  *
  * @typedef {Object} TransactionResponse
  * @property {string} id consent transaction ID
+ * @property {string} signature digital signature for 2checkout payment form processing
  */
 
 $(
@@ -223,7 +224,7 @@ $(
          * @param {TransactionResponse} transactionResponse the consent transaction response.
          */
         function redirectToPaymentPage(transactionResponse) {
-            window.location = `${orderUrl}&CUSTOMERID=${transactionResponse.id}`;
+            window.location = `${orderUrl}&customer-ext-ref=${transactionResponse.id}&signature=${transactionResponse.signature}`;
         }
     }
 );

--- a/js/pricing.js
+++ b/js/pricing.js
@@ -53,13 +53,11 @@
  */
 
 /**
- * The user's consent transaction response.
+ * The user's consent transaction ID and 2checkout signature.
  *
- * <p>As a response gets the transaction ID and the signature.
- *
- * @typedef {Object} TransactionResponse
+ * @typedef {Object} Transaction
  * @property {string} id consent transaction ID
- * @property {string} signature digital signature for 2checkout payment form processing
+ * @property {string} signature HMAC signature for 2checkout payment form processing
  */
 
 $(
@@ -181,8 +179,8 @@ $(
                 type: 'POST',
                 data: JSON.stringify(transactionRequest),
                 contentType: 'application/json',
-                success: (response) => {
-                    redirectToPaymentPage(response);
+                success: (transaction) => {
+                    redirectToPaymentPage(transaction);
                     hideRedirect();
                 },
                 error: (jqXhr) => {
@@ -220,10 +218,10 @@ $(
         /**
          * Redirects to the payment page.
          *
-         * @param {TransactionResponse} transactionResponse the consent transaction response.
+         * @param {Transaction} transaction the consent transaction response.
          */
-        function redirectToPaymentPage(transactionResponse) {
-            window.location = `${orderUrl}&customer-ext-ref=${transactionResponse.id}&signature=${transactionResponse.signature}`;
+        function redirectToPaymentPage(transaction) {
+            window.location = `${orderUrl}&customer-ext-ref=${transaction.id}&signature=${transaction.signature}`;
         }
     }
 );

--- a/js/pricing.js
+++ b/js/pricing.js
@@ -224,7 +224,33 @@ $(
          * @param {TransactionResponse} transactionResponse the consent transaction response.
          */
         function redirectToPaymentPage(transactionResponse) {
-            window.location = `${orderUrl}&customer-ext-ref=${transactionResponse.id}&signature=${transactionResponse.signature}`;
+            window.location = `${orderUrl}${urlParams(transactionResponse)}`;
+        }
+
+        /**
+         * Creates payment URL parameters string.
+         *
+         * @param {TransactionResponse} transactionResponse the consent transaction response.
+         * @return {string} returns parameters string.
+         */
+        function urlParams(transactionResponse) {
+            const params = {
+                'merchant': '999999999589',
+                'currency': 'EUR',
+                'tpl': 'default',
+                'prod': '4HJME1JJDF',
+                'qty': 1,
+                'customer-ext-ref': transactionResponse.id,
+                'signature': transactionResponse.signature
+            };
+            let paramsString = "";
+            for (let key in params) {
+                if (paramsString != "") {
+                    paramsString += "&";
+                }
+                paramsString += `${key}=${encodeURIComponent(params[key])}`;
+            }
+            return paramsString;
         }
     }
 );

--- a/js/pricing.js
+++ b/js/pricing.js
@@ -75,7 +75,7 @@ $(
         const $consentCheckboxes = $("input[type='checkbox'].consent");
         const disabledBtnTitle = 'Read and agree to the terms to\xA0continue';
 
-        const reCaptchaSiteKey = "{{site.data.payment_config.reCaptchaSiteKey}}"
+        const reCaptchaSiteKey = "{{site.data.payment_config.reCaptchaSiteKey}}";
         const orderUrl = "{{site.data.payment_config.orderUrl}}";
 
         const apiUrl = getApiUrl();
@@ -224,33 +224,7 @@ $(
          * @param {TransactionResponse} transactionResponse the consent transaction response.
          */
         function redirectToPaymentPage(transactionResponse) {
-            window.location = `${orderUrl}${urlParams(transactionResponse)}`;
-        }
-
-        /**
-         * Creates payment URL parameters string.
-         *
-         * @param {TransactionResponse} transactionResponse the consent transaction response.
-         * @return {string} returns parameters string.
-         */
-        function urlParams(transactionResponse) {
-            const params = {
-                'merchant': '999999999589',
-                'currency': 'EUR',
-                'tpl': 'default',
-                'prod': '4HJME1JJDF',
-                'qty': 1,
-                'customer-ext-ref': transactionResponse.id,
-                'signature': transactionResponse.signature
-            };
-            let paramsString = "";
-            for (let key in params) {
-                if (paramsString != "") {
-                    paramsString += "&";
-                }
-                paramsString += `${key}=${encodeURIComponent(params[key])}`;
-            }
-            return paramsString;
+            window.location = `${orderUrl}&customer-ext-ref=${transactionResponse.id}&signature=${transactionResponse.signature}`;
         }
     }
 );

--- a/js/pricing.js
+++ b/js/pricing.js
@@ -182,8 +182,7 @@ $(
                 data: JSON.stringify(transactionRequest),
                 contentType: 'application/json',
                 success: (response) => {
-                    const transactionResponse = JSON.parse(response);
-                    redirectToPaymentPage(transactionResponse);
+                    redirectToPaymentPage(response);
                     hideRedirect();
                 },
                 error: (jqXhr) => {

--- a/js/pricing.js
+++ b/js/pricing.js
@@ -55,7 +55,7 @@
 /**
  * The user's consent transaction response.
  *
- * <p>As a response gets the transaction ID.
+ * <p>As a response gets the transaction ID and the signature.
  *
  * @typedef {Object} TransactionResponse
  * @property {string} id consent transaction ID


### PR DESCRIPTION
Order URL was updated according 2checkout requirements for ConvertPlus plan.  

The checkout url was updated, the `CUSTOMERID` parameter was changed to `customer-ext-ref` and `signature` was added. On the server side signature generator was implemented. https://github.com/SpineEventEngine/site-backend/pull/8 