### PR TITLE
Update email address

### DIFF
--- a/_data/support.yml
+++ b/_data/support.yml
@@ -1,6 +1,6 @@
 email: spine-developers@teamdev.com
 emailDev: developers@spine.io
-emailSales: sales@teamdev.com
+emailSales: sales@spine.io
 emailPrivacy: privacy@teamdev.com
 
 discussionGroup: https://groups.google.com/a/spine.io/g/discussion


### PR DESCRIPTION
This PR brings a new email `sales@spine.io` instead of the `sales@teamdev.com`.