### PR TITLE
Remove subtitles on the `Getting Help` page

### DIFF
--- a/_includes/getting-help/service-section.html
+++ b/_includes/getting-help/service-section.html
@@ -4,7 +4,6 @@
 <section class="service-section">
     <div class="container-fluid content-holder">
         <h1 class="section-title light">Services</h1>
-        <p class="subtitle">Get assistance by the core engineers of the framework.</p>
         <div class="support-card compare-support">
             <div class="header">
                 <i class="header-icon fas fa-brackets-curly"></i>

--- a/_sass/pages/_getting-help.scss
+++ b/_sass/pages/_getting-help.scss
@@ -29,6 +29,9 @@
   $card-shadow: 0px 8px 10px 0px rgba(black, .02),
                 0px 0px 0px 1px inset rgba(33, 33, 33, .07);
 
+  // A custom width is used here to keep the compared items together as long as possible.
+  $mobile-card-screen-size: 610px;
+
   background-color: $body-light-gray-color;
 
   .section-title {
@@ -349,8 +352,7 @@
     gap: 0 var(--pricing-card-gap-between);
     margin: 32px 0;
 
-    // A custom width is used here to keep the compared items together as long as possible.
-    @media (max-width: 580px) {
+    @media (max-width: $mobile-card-screen-size) {
       .header,
       .card-cell,
       .footer-cell {
@@ -438,7 +440,7 @@
 
     .action-block {
       .pricing-btn {
-        @media (max-width: $phone-large) {
+        @media (max-width: $mobile-card-screen-size) {
           float: none;
           width: 100%;
         }

--- a/_sass/pages/_getting-help.scss
+++ b/_sass/pages/_getting-help.scss
@@ -29,9 +29,6 @@
   $card-shadow: 0px 8px 10px 0px rgba(black, .02),
                 0px 0px 0px 1px inset rgba(33, 33, 33, .07);
 
-  $mobile-card-max-screen-size: $tablet;
-  $mobile-card-min-screen-size: $mobile-card-max-screen-size + 1;
-
   background-color: $body-light-gray-color;
 
   .section-title {

--- a/_sass/pages/_getting-help.scss
+++ b/_sass/pages/_getting-help.scss
@@ -35,17 +35,10 @@
   background-color: $body-light-gray-color;
 
   .section-title {
-    font-size: 36px;
+    font-size: 34px;
     margin-bottom: 4px;
     padding-top: 0;
-  }
-
-  .subtitle {
-    font-size: 18px;
-    font-weight: 300;
-    letter-spacing: .2px;
-    max-width: 780px;
-    margin-bottom: 24px;
+    text-align: center;
   }
 
   .support-section,
@@ -351,7 +344,7 @@
     grid-template-columns: repeat(2, 1fr);
     grid-auto-rows: min-content;
     gap: 0 var(--pricing-card-gap-between);
-    margin: 20px 0;
+    margin: 32px 0;
 
     // A custom width is used here to keep the compared items together as long as possible.
     @media (max-width: 580px) {

--- a/_sass/pages/_getting-help.scss
+++ b/_sass/pages/_getting-help.scss
@@ -336,6 +336,12 @@
           }
         }
       }
+
+      a {
+        &.external {
+          white-space: normal;
+        }
+      }
     }
   }
 

--- a/getting-help/index.html
+++ b/getting-help/index.html
@@ -7,7 +7,6 @@ layout: default
 
 <section class="support-section">
     <div class="container-fluid content-holder">
-        <p class="subtitle">See resources to help you get your Spine project up and running.</p>
         <div class="row">
             <div class="col-lg-4 support-get-started">
                 <div class="support-container">


### PR DESCRIPTION
This PR removes subtitles on the `Getting Help` page.

Also, column widths were fixed on mobile devices and the CSS variables were refactored.