### PR TITLE
Make scripts friendlier to custom setups

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -41,6 +41,11 @@ LICENSE text
 
 # Declare files that will always have LF line endings on checkout.
 *.sh text eol=lf
+_script/jekyll-build eol=lf
+_script/embed-code eol=lf
+_script/check-samples eol=lf
+_script/jekyll-serve eol=lf
+_script/proof-links eol=lf
 gradlew text eol=lf
 pull text eol=lf
 

--- a/_script/check-samples
+++ b/_script/check-samples
@@ -1,6 +1,15 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Load environment variables for the case of execution from the Gradle build.
-source ~/.bash_profile
+# Load environment variables for the case of execution from the Gradle build if they exist.
+BASH_PROFILE=~/.bash_profile
+BASH_RC=~/.bashrc
+
+if [ -f ${BASH_PROFILE} ]; then
+  echo "Using user's local bash profile."
+  . ${BASH_PROFILE}
+elif [ -f ${BASH_RC} ]; then
+  echo "Using user's local bash runtime configuration."
+  . ${BASH_RC}
+fi
 
 bundle exec jekyll checkCodeSamples

--- a/_script/embed-code
+++ b/_script/embed-code
@@ -1,7 +1,16 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Load environment variables for the case of execution from the Gradle build.
-source ~/.bash_profile
+# Load environment variables for the case of execution from the Gradle build if they exist.
+BASH_PROFILE=~/.bash_profile
+BASH_RC=~/.bashrc
+
+if [ -f ${BASH_PROFILE} ]; then
+  echo "Using user's local bash profile."
+  . ${BASH_PROFILE}
+elif [ -f ${BASH_RC} ]; then
+  echo "Using user's local bash runtime configuration."
+  . ${BASH_RC}
+fi
 
 # Ensure `_code` files are fetched.
 git submodule update --remote --merge --recursive

--- a/_script/jekyll-build
+++ b/_script/jekyll-build
@@ -1,6 +1,15 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Load environment variables for the case of execution from the Gradle build.
-source ~/.bash_profile
+# Load environment variables for the case of execution from the Gradle build if they exist.
+BASH_PROFILE=~/.bash_profile
+BASH_RC=~/.bashrc
+
+if [ -f ${BASH_PROFILE} ]; then
+  echo "Using user's local bash profile."
+  . ${BASH_PROFILE}
+elif [ -f ${BASH_RC} ]; then
+  echo "Using user's local bash runtime configuration."
+  . ${BASH_RC}
+fi
 
 bundle exec jekyll build

--- a/_script/jekyll-serve
+++ b/_script/jekyll-serve
@@ -1,6 +1,15 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Load environment variables for the case of execution from the Gradle build.
-source ~/.bash_profile
+# Load environment variables for the case of execution from the Gradle build if they exist.
+BASH_PROFILE=~/.bash_profile
+BASH_RC=~/.bashrc
+
+if [ -f ${BASH_PROFILE} ]; then
+  echo "Using user's local bash profile."
+  . ${BASH_PROFILE}
+elif [ -f ${BASH_RC} ]; then
+  echo "Using user's local bash runtime configuration."
+  . ${BASH_RC}
+fi
 
 bundle exec jekyll serve

--- a/_script/proof-links
+++ b/_script/proof-links
@@ -1,7 +1,16 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Load environment variables for the case of execution from the Gradle build.
-source ~/.bash_profile
+# Load environment variables for the case of execution from the Gradle build if they exist.
+BASH_PROFILE=~/.bash_profile
+BASH_RC=~/.bashrc
+
+if [ -f ${BASH_PROFILE} ]; then
+  echo "Using user's local bash profile."
+  . ${BASH_PROFILE}
+elif [ -f ${BASH_RC} ]; then
+  echo "Using user's local bash runtime configuration."
+  . ${BASH_RC}
+fi
 
 # Check the links used by the site.
 bundle exec htmlproofer --assume-extension ./_site --only_4xx --http-status-ignore "429"


### PR DESCRIPTION
This PR improves our helper scripts setup allowing users with different Bash setups to use them without being forced to create custom configuration files.

It is usually a preferred way to rely on the user's `env` configuration over hard-coding the `/bin/bash` shebang. Also, users may not use `bash` as their default shell, then they will not have the bash profile file available. The last change is the usage of the POSIX-compatible [dot command](https://www.shell-tips.com/bash/source-dot-command/) over the Bash-specific `source` command to make the script a bit more friendly to other shells.