### PR TITLE
Add Proto `repeated` and `map` naming convention

### DIFF
--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -522,7 +522,7 @@ import "spine/net/email_address.proto";
 message User {
     // ...
 
-    repeated spine.net.EmailAddress recovery_emails = 42 [(distinct) = true];
+    repeated spine.net.EmailAddress recovery_email = 42 [(distinct) = true];
 }
 ```
 

--- a/docs/introduction/naming-conventions.md
+++ b/docs/introduction/naming-conventions.md
@@ -175,6 +175,45 @@ message CreateTask {
 </div>
 </div>
 
+### `repeated` and `map` fields
+
+We recommend naming `repeated` and `map` fields using singular nouns as such a naming appears 
+to be closer to the language we speak. It also provides easier to use generated code.
+
+<p class="note">This convention contradicts with the official 
+[Protobuf Style Guide](https://developers.google.com/protocol-buffers/docs/style#repeated_fields 
+"Protocol Buffers Style Guide") which suggests naming `map` and `repeated` fields after plural
+nouns. Knowing this, we still recommend singular because of the following.
+
+The code generated for a `repeated` and `map` field named after a singular noun is closer to 
+real English. For the code related to the Domain-Driven Design this is far more important than 
+the consistency with the style guide.</p>
+
+So when defining `repeated` and `map` fields use:
+
+<div class="row">
+<div class="col-xl-6">
+<p>Singulars</p>
+{% highlight proto %}
+message Task {
+    TaskId id = 1;
+    repeated SubTaskId subtask = 2;
+    map<string, string> user_label = 3;
+}
+{% endhighlight %}
+</div>
+<div class="col-xl-6">
+<p>Over pluralized names</p>
+{% highlight proto %}
+message CreateTask {
+    TaskId id = 1;
+    repeated SubTaskId subtasks = 2;
+    map<string, string> user_labels = 3;
+}
+{% endhighlight %}
+</div>
+</div>
+
 ### Commands
 
 A command is defined as an imperative:


### PR DESCRIPTION
In this PR I have ported our naming conventions for `repeated` and `map` types from the repository Wiki [page](https://github.com/SpineEventEngine/SpineEventEngine.github.io/wiki/Protobuf-Code-Style#naming-repeated-and-map-fields) to the published docs.

There's a known code highlight [issue](https://github.com/rouge-ruby/rouge/issues/1640) with Proto examples that have the `map` type.