### PR TITLE
Make code snippets with the horizontal scroll on mobile

### DIFF
--- a/_sass/base/_code-highlight.scss
+++ b/_sass/base/_code-highlight.scss
@@ -44,6 +44,7 @@ pre {
     overflow: auto;
     color: #a9b7c6; // Color for the dark theme while site is loading
     overflow-wrap: normal; // For the Safari browser
+    word-wrap: normal; // Overrides default Bootstrap property to fix the overflow in Safari
 
     @media print {
       white-space: pre-wrap;


### PR DESCRIPTION
This PR overrides the default Bootstrap property to make code snippets with the horizontal scroll in mobile Safari.