### PR TITLE
Change `Show code` on `Hide code` if the item is opened

### DIFF
--- a/_sass/pages/_landing.scss
+++ b/_sass/pages/_landing.scss
@@ -84,17 +84,28 @@
   }
 
   .code-toggle {
-    color: $gray-300;
     border-bottom: 1px dotted;
-    pointer-events: none;
 
     &:hover {
       text-decoration: none;
     }
 
     &.collapsed {
-      color: $mainBrandColor;
-      pointer-events: auto;
+      .show-code {
+        display: inline;
+      }
+
+      .hide-code {
+        display: none;
+      }
+    }
+
+    .show-code {
+      display: none;
+    }
+
+    .hide-code {
+      display: inline;
     }
   }
 

--- a/index.html
+++ b/index.html
@@ -15,7 +15,10 @@ bodyclass: promo-page
                     <a href="https://developers.google.com/protocol-buffers/">Protobuf</a>.
                     <a class="code-toggle collapsed"
                        href="#step-one"
-                       data-toggle="collapse">Show&nbsp;code</a>
+                       data-toggle="collapse">
+                        <span class="show-code">Show&nbsp;code</span>
+                        <span class="hide-code">Hide&nbsp;code</span>
+                    </a>
                 </p>
             </div>
         </div>
@@ -86,7 +89,10 @@ message Task {
                     message delivery, and other environment matters are isolated from the main code.
                     <a class="code-toggle collapsed"
                        href="#step-three"
-                       data-toggle="collapse">Show&nbsp;code</a>
+                       data-toggle="collapse">
+                        <span class="show-code">Show&nbsp;code</span>
+                        <span class="hide-code">Hide&nbsp;code</span>
+                    </a>
                 </p>
             </div>
         </div>
@@ -165,7 +171,10 @@ public class TaskCreationTest extends ContextAwareTest {
                     environment(s) with a few lines of code.
                     <a class="code-toggle collapsed"
                        href="#step-four"
-                       data-toggle="collapse">Show&nbsp;code</a>
+                       data-toggle="collapse">
+                        <span class="show-code">Show&nbsp;code</span>
+                        <span class="hide-code">Hide&nbsp;code</span>
+                    </a>
                 </p>
             </div>
         </div>


### PR DESCRIPTION
This PR brings updates to the collapsible functionality on the home page.

The button label changes to the `Hide code` if the item is opened.