### PR TITLE
Add switcher for Java / Kotlin source code samples

### DIFF
--- a/AUTHORING.md
+++ b/AUTHORING.md
@@ -13,6 +13,7 @@ This document is a guide for adding content to the [spine.io](https://spine.io) 
 - [Testing broken links](#testing-broken-links)
 - [Adding email links](#adding-email-links)
 - [Managing the “Prev”/“Next” buttons in the documentation](#managing-the-prevnext-buttons-in-the-documentation)
+- [Using Java / Kotlin switcher for source code samples](#using-java--kotlin-switcher-for-source-code-samples)
 
 <small><i><a href='http://ecotrust-canada.github.io/markdown-toc/'>Table of contents generated with markdown-toc</a></i></small>
 
@@ -167,3 +168,60 @@ next_btn:
 - `_includes/doc-next-prev-nav.html` - the navigation template with the automatic button generation;
 - `_sass/modules/_doc-next-prev-nav.scss` - navigation styles;
 - `_layouts/docs.html` - the documentation layout where the `doc-next-prev-nav` is included.
+
+# Using Java / Kotlin switcher for source code samples
+
+The switch state will be saved globally so that the user can navigate between pages.
+
+### Usage
+
+To show language tabs use the structure below.
+Add corresponding `.java` and `.kotlin` classes for `div`s with content.
+```
+<div class="code-tabs">
+    <div class="code-tab-content java">
+         Any Java content here
+    </div>
+    <div class="code-tab-content kotlin">
+         Any Kotlin content here
+    </div>
+</div>
+```
+
+In **markdown**, all tags should be left-aligned. This way, the blocks 
+of code will not be broken:
+
+```
+<div class="code-tabs">
+<div class="code-tab-content java">
+Any Java content here
+</div>
+<div class="code-tab-content kotlin">
+Any Kotlin content here
+</div>
+</div>
+```
+
+If you don't need to display the tabs, but only need to show a specific paragraph of text 
+or change the title depending on the language, just use this:
+```
+<div class="code-tab-content java">
+# Getting started with Spine in Java
+</div>
+
+<div class="code-tab-content kotlin">
+# Getting started with Spine in Kotlin
+</div>
+```
+
+To change only some of the words in a sentence, use the `<span>` tag with the `.inline` class:
+```
+A minimal client-server application in
+<span class="code-tab-content inline java">Java</span>
+<span class="code-tab-content inline kotlin">Kotlin</span>
+which handles one command to print some text...
+```
+
+**Related files:**
+- `_sass/modules/_code-tabs.scss` - styles for the code tabs;
+- `js/code-tabs.js` - code tab implementation.

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -119,6 +119,7 @@
   <script src="{{ site.baseurl }}/js/common.js" type="text/javascript" charset="utf-8"></script>
   <script src="{{ site.baseurl }}/js/snackbar.js" type="text/javascript" charset="utf-8"></script>
   <script src="{{ site.baseurl }}/js/sticky-elements.js" type="text/javascript" charset="utf-8"></script>
+  <script src="{{ site.baseurl }}/js/code-tabs.js" type="text/javascript" charset="utf-8"></script>
   <script src="{{ site.baseurl }}/js/doc-side-nav.js" type="text/javascript" charset="utf-8"></script>
   <script src="{{ site.baseurl }}/js/scroll-to-anchor.js" type="text/javascript" charset="utf-8"></script>
 

--- a/_sass/base/_colors.scss
+++ b/_sass/base/_colors.scss
@@ -6,6 +6,7 @@ $body-light-gray-color: #f6f8fA;
 $warningColor: #deba32;
 $nav-blue-gradient: linear-gradient(152deg, #1378DA 0%, #0B64CC 100%);
 $light-blue-bg-color: #edf8ff;
+$note-bg-color: #e0f2ff;
 
 // Dividers
 $dividerColor: rgba(0, 0, 0, .08);

--- a/_sass/base/_text.scss
+++ b/_sass/base/_text.scss
@@ -73,7 +73,7 @@ p {
   }
 
   &.note {
-    background-color: #e0f2ff;
+    background-color: $note-bg-color;
     border-left: 4px solid $mainBrandColor;
     padding: 12px 24px 13px;
     color: $black;

--- a/_sass/modules/_code-tabs.scss
+++ b/_sass/modules/_code-tabs.scss
@@ -1,0 +1,86 @@
+/*!
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Classes are generated in the `js/code-tabs.js` file.
+
+$code-tab-color: $note-bg-color;
+$code-tab-border-color: #d4e8f9;
+
+.code-tabs {
+  margin-top: 18px;
+
+  .tabs {
+    margin-bottom: 8px;
+
+    .tab {
+      display: inline-block;
+      border: 1px solid #d4e8f9;
+      padding: 6px 16px 7px;
+      cursor: pointer;
+      font-family: $main-font;
+      font-size: 14px;
+      line-height: 1;
+      text-transform: capitalize;
+      color: $mainBrandColor;
+      @include transition(all .2s ease-in-out);
+
+      &:first-child {
+        border-radius: $border-radius 0 0 $border-radius;
+      }
+
+      &:last-child {
+        border-radius: 0 $border-radius $border-radius 0;
+      }
+
+      &:not(:first-child) {
+        margin-left: -1px;
+      }
+
+      &:hover {
+        background-color: rgba($code-tab-color, .26);
+      }
+
+      &.selected {
+        background-color: $code-tab-color;
+        color: $black;
+      }
+    }
+  }
+
+  .code-tab-content {
+    p {
+      margin-bottom: 8px;
+    }
+  }
+}
+
+.code-tab-content {
+  display: none;
+
+  &.show {
+    display: block;
+  }
+}

--- a/_sass/modules/_code-tabs.scss
+++ b/_sass/modules/_code-tabs.scss
@@ -31,6 +31,7 @@ $code-tab-border-color: #d4e8f9;
 
 .code-tabs {
   margin-top: 18px;
+  margin-bottom: 20px;
 
   .tabs {
     margin-bottom: 8px;
@@ -82,5 +83,9 @@ $code-tab-border-color: #d4e8f9;
 
   &.show {
     display: block;
+  }
+
+  &.inline.show {
+    display: inline-block;
   }
 }

--- a/_sass/pages/_landing.scss
+++ b/_sass/pages/_landing.scss
@@ -118,6 +118,10 @@
       text-decoration: none;
     }
   }
+
+  .code-tabs {
+    margin-top: 0;
+  }
 }
 
 // Documentation call to action

--- a/css/style.scss
+++ b/css/style.scss
@@ -34,6 +34,7 @@
 @import "modules/color-selector";
 @import "modules/snackbar";
 @import "modules/redirect-screen";
+@import "modules/code-tabs";
 
 @import "pages/_blog";
 @import "pages/_docs";

--- a/js/code-tabs.js
+++ b/js/code-tabs.js
@@ -27,41 +27,50 @@
 /**
  * This script contains helper functions for switching between Java/Kotlin source code examples.
  *
- * The selected language will be saved in cookies so that the user can switch between pages.
+ * The selected language will be saved in cookies so that the user can navigate between pages.
  *
- * To show tabs in HTML or markdown file use this structure:
+ * To show tabs use this structure:
  * ```
  * <div class="code-tabs">
- *     <div class="code-tab-content java"
+ *     <div class="code-tab-content java">
  *          Any Java content here
  *     </div>
- *
- *     <div class="code-tab-content kotlin"
+ *     <div class="code-tab-content kotlin">
  *          Any Kotlin content here
  *     </div>
  * </div>
  * ```
  *
- * In markdown all tags should be aligned to the left side so that blocks of code
+ * In markdown, all tags should be left-aligned. This way, the blocks of code
  * will not be broken:
  * ```
  * <div class="code-tabs">
- * <div class="code-tab-content java"
+ * <div class="code-tab-content java">
  * Any Java content here
  * </div>
- *
- * <div class="code-tab-content kotlin"
+ * <div class="code-tab-content kotlin">
  * Any Kotlin content here
  * </div>
  * </div>
  * ```
  *
- * If it is needed to display a specific paragraph of text or change the title for some
- * language and not display tabs, simply use this:
+ * If you don't need to display the tabs, but only need to show a specific paragraph of text
+ * or change the title depending on the language, just use this:
  * ```
  * <div class="code-tab-content java">
- *     This text will be shown only for the Java language.
+ * # Getting started with Spine in Java
  * </div>
+ * <div class="code-tab-content kotlin">
+ * # Getting started with Spine in Kotlin
+ * </div>
+ * ```
+ *
+ * To change only some of the words in a sentence, use the `<span>` tag with the `.inline` class:
+ * ```
+ * A minimal client-server application in
+ * <span class="code-tab-content inline java">Java</span>
+ * <span class="code-tab-content inline kotlin">Kotlin</span>
+ * which handles one command to print some text...
  * ```
  */
 

--- a/js/code-tabs.js
+++ b/js/code-tabs.js
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * This script contains helper functions for switching between Java/Kotlin source code examples.
+ *
+ * The selected language will be saved in cookies so that the user can switch between pages.
+ *
+ * To show tabs in HTML or markdown file use this structure:
+ * ```
+ * <div class="code-tabs">
+ *     <div class="code-tab-content java"
+ *          Any Java content here
+ *     </div>
+ *
+ *     <div class="code-tab-content kotlin"
+ *          Any Kotlin content here
+ *     </div>
+ * </div>
+ * ```
+ *
+ * In markdown all tags should be aligned to the left side so that blocks of code
+ * will not be broken:
+ * ```
+ * <div class="code-tabs">
+ * <div class="code-tab-content java"
+ * Any Java content here
+ * </div>
+ *
+ * <div class="code-tab-content kotlin"
+ * Any Kotlin content here
+ * </div>
+ * </div>
+ * ```
+ *
+ * If it is needed to display a specific paragraph of text or change the title for some
+ * language and not display tabs, simply use this:
+ * ```
+ * <div class="code-tab-content java">
+ *     This text will be shown only for the Java language.
+ * </div>
+ * ```
+ */
+
+'use strict';
+
+$(
+    function() {
+        const cookieCodeLang = 'codeLang';
+        const $codeTabs = $('.code-tabs');
+        const $codeTabContent = $('.code-tab-content');
+
+        const primaryLang = 'java';
+        const secondaryLang = 'kotlin';
+
+        addTabSwitcher();
+        initCodeLangSwitcher();
+
+        /**
+         * Adds a tab switcher to the DOM.
+         */
+        function addTabSwitcher() {
+            $codeTabs.each(function() {
+                const tabBlock = $(this);
+                createTab(tabBlock, createTabContainer(tabBlock));
+            });
+        }
+
+        /**
+         * Creates a container for tabs.
+         *
+         * @param tabBlock a block that contains tabs.
+         * @return {jQuery|HTMLElement} tabContainer a container for tabs.
+         */
+        function createTabContainer(tabBlock) {
+            const tabContainer = $('<div class="tabs"></div>');
+            tabBlock.prepend(tabContainer);
+            return tabContainer;
+        }
+
+        /**
+         * Creates a tab inside the container for each `code-tab-content` element.
+         *
+         * @param tabBlock a block that contains tabs.
+         * @param tabContainer a container for tabs.
+         */
+        function createTab(tabBlock, tabContainer) {
+            const tabContent = tabBlock.find($codeTabContent);
+            tabContent.each(function () {
+                const tabName = $(this).attr('class').split(' ')[1];
+                const item = $(`<div class="tab ${tabName}">${tabName}</div>`);
+                tabContainer.append(item);
+            });
+        }
+
+        /**
+         * Inits a code language switcher.
+         *
+         * By default, sets the primary code language to the `cookie`.
+         * On a tab click switches between code languages.
+         */
+        function initCodeLangSwitcher() {
+            const cookieValue = Cookies.get(cookieCodeLang);
+
+            if (cookieValue == null) {
+                setCodeLang(primaryLang);
+            } else {
+                primaryLang === cookieValue && setCodeLang(primaryLang);
+                secondaryLang === cookieValue && setCodeLang(secondaryLang);
+            }
+
+            $('.tab').click(function() {
+                const lang = $(this).attr('class').split(' ')[1];
+
+                if (lang === primaryLang) {
+                    setCodeLang(primaryLang);
+                } else {
+                    setCodeLang(secondaryLang);
+                }
+            });
+        }
+
+        /**
+         * Sets the chosen code language to the `cookie` and adds corresponding
+         * CSS classes to the selected tab and content element.
+         *
+         * The CSS file is located at `_sass/modules/_code-tabs.scss`.
+         *
+         * @param codeLang a selected code language.
+         */
+        function setCodeLang(codeLang) {
+            Cookies.set(cookieCodeLang, codeLang);
+            $('.tab').removeClass('selected');
+            $('.tab.' + codeLang).addClass('selected');
+            $codeTabContent.removeClass('show');
+            $('.code-tab-content.' + codeLang).addClass('show');
+        }
+    }
+);

--- a/js/code-tabs.js
+++ b/js/code-tabs.js
@@ -73,6 +73,7 @@ $(
         const $codeTabs = $('.code-tabs');
         const $codeTabContent = $('.code-tab-content');
 
+        // TODO:2021-03-17:juliaevseeva: Update the logic to make it easy to add new programming languages.
         const primaryLang = 'java';
         const secondaryLang = 'kotlin';
 


### PR DESCRIPTION
This PR closes #413.

This PR brings the switсher for the Java / Kotlin source code samples.

Also, the implementation supports the possibility to change some of the words in a sentence or a paragraph of text, depending on the selected language. 

The switch state will be saved when the user navigates between pages.

The usage guide was added to the [`AUTHORING.md`](https://github.com/SpineEventEngine/SpineEventEngine.github.io/blob/master/AUTHORING.md) file.