### PR TITLE
Remove Blog item from all navigations

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -31,7 +31,6 @@
             <li><p><a href="{{ site.baseurl }}/release-notes">Release Notes</a></p></li>
             <li><p><a href="{{ site.baseurl }}/faq">FAQ</a></p></li>
             <li><p><a href="{{ site.baseurl }}/getting-help">Getting Help</a></p></li>
-            <li><p><a href="{{ site.baseurl }}/blog">Blog</a></p></li>
           </ul>
         </div>
         <hr class="footer-sections" />

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -40,7 +40,6 @@
                         <li class="nav-item"><a href="{{ site.baseurl }}/release-notes/" {% if current[1]=='release-notes' %} class='nav-item-link current' {% else %} class='nav-item-link' {% endif %}><span>Release Notes</span></a></li>
                         <li class="nav-item"><a href="{{ site.baseurl }}/faq/" {% if current[1]=='faq' %} class='nav-item-link current' {% else %} class='nav-item-link' {% endif %}><span>FAQ</span></a></li>
                         <li class="nav-item"><a href="{{ site.baseurl }}/getting-help/" {% if current[1]=='getting-help' %} class='nav-item-link current' {% else %} class='nav-item-link' {% endif %}><span>Getting Help</span></a></li>
-                        <li class="nav-item"><a href="{{ site.baseurl }}/blog/" {% if current[1]=='blog' %} class='nav-item-link current' {% else %} class='nav-item-link' {% endif %}><span>Blog</span></a></li>
                         <li class="nav-item"><a class="nav-item-link github-icon" href="https://github.com/SpineEventEngine" target="_blank"><i class="fab fa-github fa-lg"></i></a></li>
                     </ul>
                 </nav>


### PR DESCRIPTION
This PR closes #437.

This PR removes the “Blog” item from the top navigation and footer.