### PR TITLE
Add Google Tag Manager script.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,6 +25,7 @@ js_api_doc: https://spine.io/web/reference/client-js
 dart_api_doc: https://spine.io/dart/reference
 
 google_analytics_tag: UA-71822190-1
+google_tag_manager_id: GTM-T6NZS3S
 
 # Gems
 plugins:

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -22,6 +22,14 @@
       ga('send', 'pageview');
   </script>
 
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+            new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+          j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+          'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','{{ site.google_tag_manager_id }}');</script>
+  <!-- End Google Tag Manager -->
+
   <link rel="alternate" type="application/rss+xml" title="Spine Blog RSS" href="/feed.xml">
 
   <!-- Fontawesome Icons -->
@@ -143,6 +151,11 @@
   {% if page.customjs %}
     <script defer type="text/javascript" src="{{ page.customjs }}"></script>
   {% endif %}
+
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ site.google_tag_manager_id }}"
+                    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
 
 </body>
 </html>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -23,11 +23,13 @@
   </script>
 
   <!-- Google Tag Manager -->
-  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-            new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-          j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-          'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer','{{ site.google_tag_manager_id }}');</script>
+  <script>
+    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+              new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+            j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+            'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','{{ site.google_tag_manager_id }}');
+  </script>
   <!-- End Google Tag Manager -->
 
   <link rel="alternate" type="application/rss+xml" title="Spine Blog RSS" href="/feed.xml">
@@ -153,8 +155,10 @@
   {% endif %}
 
   <!-- Google Tag Manager (noscript) -->
-  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ site.google_tag_manager_id }}"
-                    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <noscript>
+    <iframe src="https://www.googletagmanager.com/ns.html?id={{ site.google_tag_manager_id }}"
+            height="0" width="0" style="display:none; visibility:hidden"></iframe>
+  </noscript>
   <!-- End Google Tag Manager (noscript) -->
 
 </body>


### PR DESCRIPTION
Google Tag Manager script was added in this PR. It will replace outdated `analytics.js` script. 

On first stage I will setup new GA4 Property and connect it with UA Property. Then will remove the outdated analytics script. 