### PR TITLE
Remove Google Universal Analytics script

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,7 +24,6 @@ web_api_doc: https://spine.io/web/reference
 js_api_doc: https://spine.io/web/reference/client-js
 dart_api_doc: https://spine.io/dart/reference
 
-google_analytics_tag: UA-71822190-1
 google_tag_manager_id: GTM-T6NZS3S
 
 # Gems

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -12,16 +12,6 @@
     <title>Spine / {{ page.title }}</title>
   {% endif %}
 
-  <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-      ga('create', '{{ site.google_analytics_tag }}', 'auto');
-      ga('send', 'pageview');
-  </script>
-
   <!-- Google Tag Manager -->
   <script>
     (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':


### PR DESCRIPTION
The Google Universal Analytics script was removed in this PR, because we will use Google Tag Manager for properties management. 