### PR TITLE
Add the release notes for Spine 1.8.2

### DIFF
--- a/_data/navigation/release_notes_nav.yml
+++ b/_data/navigation/release_notes_nav.yml
@@ -1,3 +1,7 @@
+- page: "2022"
+  children:
+    - page: "v1.8.2"
+      url: /release-notes/2022/v1.8.2
 - page: "2021"
   children:
     - page: "v1.8.0"

--- a/release-notes/2022/v1.8.2.md
+++ b/release-notes/2022/v1.8.2.md
@@ -49,7 +49,7 @@ See [this PR](https://github.com/SpineEventEngine/jdbc-storage/pull/162) for mor
 
 Also, the versions of dependencies were updated:
 
-* HikariCP version is set to`4.0.3`, which is the latest available version compatible with Java 8;
+* HikariCP version is set to `4.0.3`, which is the latest available version compatible with Java 8;
 * H2 is now used in its latest `2.1.214` version, eliminating the currently known vulnerabilities.
 
 ## Web
@@ -58,8 +58,6 @@ In this maintenance release, `web` module got the upgrades to the third-party Ja
 dependencies in use.
 
 ## Dart
-
-This is a part of Spine release in version `1.8.2`.
 
 A major change in this update is the removal of the previous Firebase client implementation, 
 which relied upon the recently discontinued 

--- a/release-notes/2022/v1.8.2.md
+++ b/release-notes/2022/v1.8.2.md
@@ -1,0 +1,71 @@
+---
+title: Release Notes v1.8.2
+headline: Release Notes
+bodyclass: docs release-notes
+layout: release-notes
+sidenav: release-notes-side-nav.html
+date: Jun 29, 2022
+---
+
+# Spine 1.8.2
+
+## Core Java
+
+This is a maintenance release of Spine core libraries. It extends the existing API, 
+primarily focusing on adding new configuration knobs.
+
+In particular, these changes were made since the last release:
+
+* [#1443](https://github.com/SpineEventEngine/core-java/pull/1443): 
+  Expand the `io.spine.server.Server` API to allow to:
+  * obtain the Query, Subscription, and Command services after the `Server` is built;
+  * add extra gRPC services to the same server.
+
+* [#1448](https://github.com/SpineEventEngine/core-java/pull/1448): 
+  Allow supplying `Executor` for `SystemWriteSide`.
+
+* [#1454](https://github.com/SpineEventEngine/core-java/pull/1454): 
+  Allow to configure the underlying gRPC server via `GrpcContainer` API.
+
+No breaking changes to the existing API were made.
+
+## Google Cloud Java
+
+This release includes the migration to the latest Spine libraries in their `1.8.2` versions.
+
+Also, the versions of Google Cloud client libraries were updated:
+
+* Cloud Datastore is now at `2.8.0`;
+* Cloud Pubsub V1 version is set to `1.101.1`;
+* Cloud Trace version is updated to `2.2.0`.
+
+## JDBC Storage
+
+One notable change in this update is an ability to order and limit storage records properly,
+when executing read-side queries. 
+
+Previously, there were issues in some scenarios. 
+See [this PR](https://github.com/SpineEventEngine/jdbc-storage/pull/162) for more details.
+
+Also, the versions of dependencies were updated:
+
+* HikariCP version is set to`4.0.3`, which is the latest available version compatible with Java 8;
+* H2 is now used in its latest `2.1.214` version, eliminating the currently known vulnerabilities.
+
+## Web
+
+In this maintenance release, `web` module got the upgrades to the third-party JavaScript
+dependencies in use.
+
+## Dart
+
+This is a part of Spine release in version `1.8.2`.
+
+A major change in this update is the removal of the previous Firebase client implementation, 
+which relied upon the recently discontinued 
+[`firebase-dart` package](https://github.com/googlearchive/firebase-dart). 
+
+From now on, users will be able to use the library of their choice 
+by implementing the corresponding interface.
+
+The rest of the library's public API remains intact.


### PR DESCRIPTION
This changeset adds the notes for the most recent public release of Spine Event Engine.