### PR TITLE
Improve dependency reports

### DIFF
--- a/js/oss-licenses.js
+++ b/js/oss-licenses.js
@@ -68,7 +68,7 @@ $(
             });
 
             /**
-             * Makes all markdown links external.
+             * Makes all Markdown links external.
              */
             linkElements.addClass('external');
             linkElements.attr('target', '_blank');
@@ -81,6 +81,7 @@ $(
                 const titleID =  clickedElRepoName + '-' + this.id + '-md';
                 const collapsibleContent = $(element).next('ol');
                 const reportInfoContent = collapsibleContent.next('p');
+                const whenGeneratedContent = reportInfoContent.next('p');
 
                 $(element).addClass('collapse-link collapsed');
                 $(element).attr('href', '#' + titleID);
@@ -89,35 +90,8 @@ $(
                 collapsibleContent.addClass('dependencies-container collapse');
                 collapsibleContent.attr('id', titleID);
 
-                reportInfoContent.addClass('report-info collapse');
-                reportInfoContent.attr('id', titleID + '-p');
-            });
-
-            makeReportInfoCollapsible(mdDestinationEl);
-        }
-
-        /**
-         * Makes report information content collapsible.
-         *
-         * <p>Report information contains a generation date and the name of the plugin.
-         *
-         * @param mdDestinationEl it is a `div` with a markdown content
-         */
-        function makeReportInfoCollapsible(mdDestinationEl) {
-            const reportInfoContent = mdDestinationEl.find('.report-info');
-
-            /**
-             * Inserts a new collapsible title for the paragraph with a report information.
-             */
-            const reportInfoTitleEl = "<h2 class='report-info-title collapse-link collapsed'>Report info</h2>";
-            $(reportInfoTitleEl).insertBefore(reportInfoContent);
-
-            reportInfoContent.each(function (index, element) {
-                const reportInfoID = this.id;
-                const reportInfoTitle = $(element).prev('.report-info-title');
-
-                reportInfoTitle.attr('href', '#' + reportInfoID);
-                reportInfoTitle.attr('data-toggle', 'collapse');
+                reportInfoContent.remove();
+                whenGeneratedContent.remove();
             });
         }
     }

--- a/js/oss-licenses.js
+++ b/js/oss-licenses.js
@@ -13,7 +13,17 @@ $(
         const repoName = 'repo-name';
 
         /**
-         * Loads `license-report` file from the repository.
+         * Loads the dependency report file from the repository.
+         *
+         * <p>There may be one of two report files present in the repo: `license-report.md`
+         * or `dependencies.md`. The latter is a newer version of the report, so it is loaded
+         * first. In case it is missing, `license-report.md` is loaded, as a fallback.
+         * Eventually, all Spine repositories will migrate to having `dependencies.md`.
+         *
+         * <p>The report sections describing the terms of use for dual-licensed dependencies,
+         * and another one with the credits paid to the author of Gradle plugin
+         * we use for reporting, are removed from DOM, as they are now moved
+         * to the static part of the page (see `/oss-licenses.index.html`).
          *
          * <p>Executes by clicking on the corresponding link. The destination `div` element
          * should have the `id` like `md-destination-REPO_NAME`.

--- a/oss-licenses/index.html
+++ b/oss-licenses/index.html
@@ -103,14 +103,6 @@ bodyclass: licenses
        aria-controls="md-destination">Spine Money</a>
     <div class="collapse license-content" id="md-destination-money">{% include loader.html %}</div>
 
-    <a class="collapsible-panel-title collapsed"
-       repo="https://raw.githubusercontent.com/SpineEventEngine/users"
-       repo-name="users"
-       loaded="false"
-       href="#md-destination-users"
-       data-toggle="collapse"
-       aria-expanded="false"
-       aria-controls="md-destination">Spine Users</a>
     <div class="collapse license-content" id="md-destination-users">{% include loader.html %}</div>
 </div>
 

--- a/oss-licenses/index.html
+++ b/oss-licenses/index.html
@@ -7,16 +7,18 @@ bodyclass: licenses
 
 <div class="row">
     <div class="col-lg-7">
-        <p class="page-description">The framework has a number of third-party dependencies. We respect the licensing
-            term of each library we rely on. Below is a full list of all dependencies along with their licenses,
+        <p class="page-description">The framework has a number of third-party dependencies.
+            We respect the licensing term of each library we rely on.
+            Below is a full list of all dependencies along with their licenses,
             grouped by Spine artifact.</p>
 
         <p class="page-description">The dependencies distributed under several licenses,
-            are used according their commercial-use-friendly license.</p>
+            are used according <br/>to their commercial-use-friendly license.</p>
 
         <p class="page-description">The reports are generated using
                 <a href="https://github.com/jk1/Gradle-License-Report" class="external"
-                target="_blank">Gradle-License-Report plugin</a> by Evgeny Naumenko, licensed under
+                target="_blank">Gradle-License-Report plugin</a> by Evgeny Naumenko, <br/>
+            licensed under
             <a href="https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE"
                class="external" target="_blank">Apache 2.0 License</a>.</p>
     </div>

--- a/oss-licenses/index.html
+++ b/oss-licenses/index.html
@@ -10,6 +10,15 @@ bodyclass: licenses
         <p class="page-description">The framework has a number of third-party dependencies. We respect the licensing
             term of each library we rely on. Below is a full list of all dependencies along with their licenses,
             grouped by Spine artifact.</p>
+
+        <p class="page-description">The dependencies distributed under several licenses,
+            are used according their commercial-use-friendly license.</p>
+
+        <p class="page-description">The reports are generated using
+                <a href="https://github.com/jk1/Gradle-License-Report" class="external"
+                target="_blank">Gradle-License-Report plugin</a> by Evgeny Naumenko, licensed under
+            <a href="https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE"
+               class="external" target="_blank">Apache 2.0 License</a>.</p>
     </div>
 </div>
 


### PR DESCRIPTION
In scope of this changeset, a few things were improved in relation to displaying the third-party dependencies along with their licenses:

1. New `dependencies.md` file is now loaded from each repository instead of `license-report.md` as the latter is being renamed due to [config#498](https://github.com/SpineEventEngine/config/issues/498). For those repositories, in which such a renaming is not done yet, `license-report.md` is still loaded as a fallback.

2. In reports, the repeating sections telling about dual-licensing and crediting the Gradle plugin for dependency reporting are moved from per-artifact blocks to the top of [this page](https://spine.io/oss-licenses/). Also, we don't display the generation time for each artifact, as it may be fetched from its publication date anyway.

3. Spine Users report was removed, as this library is not in active development for a few years already.

Here is a screenshot of locally rendered page with all the changes applied:

<img width="1293" alt="Screenshot 2023-11-23 at 15 55 09" src="https://github.com/SpineEventEngine/SpineEventEngine.github.io/assets/82468/910c387d-59de-4aad-a7bc-f925eec784e2">
