### PR TITLE
List all `sitemap.xml` entries with an absolute URL

### DIFF
--- a/.github/workflows/check-code-embedding.yml
+++ b/.github/workflows/check-code-embedding.yml
@@ -36,8 +36,14 @@ jobs:
         with:
           ruby-version: '2.7.4'
 
+      # Bundler version is restricted to `2.4.22`,
+      # as we want to use Ruby `2.7.4` to match GH Pages environment.
+      #
+      # Any newer versions of Bundler require Ruby 3.x,
+      # which are much newer than what's GH Pages has at the moment.
+      #
       - run: |
-          gem install bundler
+          gem install bundler -v 2.4.22
           bundle install
 
       - name: Check Embedding

--- a/.github/workflows/proof-links.yml
+++ b/.github/workflows/proof-links.yml
@@ -21,9 +21,15 @@ jobs:
         with:
           ruby-version: '2.7.4'
 
+      # Bundler version is restricted to `2.4.22`,
+      # as we want to use Ruby `2.7.4` to match GH Pages environment.
+      #
+      # Any newer versions of Bundler require Ruby 3.x,
+      # which are much newer than what's GH Pages has at the moment.
+      #
       - name: Run Jekyll build
         run: |
-          gem install bundler
+          gem install bundler -v 2.4.22
           bundle install
           bundle exec jekyll build
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -7,14 +7,14 @@ sitemap_exclude: y
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     {% for post in site.posts %}
     <url>
-        <loc>{{site.baseurl}}{{ post.url | remove: 'index.html' }}</loc>
+        <loc>{{site.url}}{{site.baseurl}}{{ post.url | remove: 'index.html' }}</loc>
     </url>
     {% endfor %}
 
     {% for page in site.pages %}
     {% if page.sitemap_exclude != 'y' %}
     <url>
-        <loc>{{site.baseurl}}{{ page.url | remove: 'index.html' }}</loc>
+        <loc>{{site.url}}{{site.baseurl}}{{ page.url | remove: 'index.html' }}</loc>
     </url>
     {% endif %}
     {% endfor %}


### PR DESCRIPTION
Previously, our `sitemap.xml` only contained relative URLs, which prevented Google Search from using this sitemap.

In this PR, absolute URLs are now used. See [Google's best practices](https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap#general-guidelines).