### PR TITLE
Use an absolute URL for sitemap in `robots.txt`

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -6,4 +6,4 @@ User-agent: *
 {% for node in site.pages %}{% if node.noindex %}{% assign isset = true %}Disallow: {{ node.url }}
 {% endif %}{% endfor %}{% if isset != true %}Disallow:
 {% endif %}
-Sitemap: {{ site.baseurl }}/sitemap.xml
+Sitemap: {{site.url}}{{ site.baseurl }}/sitemap.xml


### PR DESCRIPTION
Currently, a sitemap syntax in our `robots.txt` is incorrect, as it refers to the `sitemap.xml` file via a relative URL.


According to [Google's recommendations](https://developers.google.com/search/docs/crawling-indexing/robots/create-robots-txt), the URL must be absolute. This PR does just that.