### PR TITLE
Exclude `/dart/` from crawling

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -4,7 +4,6 @@ layout: null
 
 User-agent: *
 {% for node in site.pages %}{% if node.noindex %}{% assign isset = true %}Disallow: {{ node.url }}
-{% endif %}{% endfor %}{% if isset != true %}Disallow:
-{% endif %}
+{% endif %}{% endfor %}
 Disallow: /dart/
 Sitemap: {{site.url}}{{ site.baseurl }}/sitemap.xml

--- a/robots.txt
+++ b/robots.txt
@@ -3,7 +3,8 @@ layout: null
 ---
 
 User-agent: *
+Disallow: /dart/
 {% for node in site.pages %}{% if node.noindex %}{% assign isset = true %}Disallow: {{ node.url }}
 {% endif %}{% endfor %}
-Disallow: /dart/
+
 Sitemap: {{site.url}}{{ site.baseurl }}/sitemap.xml

--- a/robots.txt
+++ b/robots.txt
@@ -6,4 +6,5 @@ User-agent: *
 {% for node in site.pages %}{% if node.noindex %}{% assign isset = true %}Disallow: {{ node.url }}
 {% endif %}{% endfor %}{% if isset != true %}Disallow:
 {% endif %}
+Disallow: /dart/
 Sitemap: {{site.url}}{{ site.baseurl }}/sitemap.xml


### PR DESCRIPTION
Previously, there were several thousand `404` responses detected by Google Search Console review process, the majority of which were related to the generated documentation for Spine Dart client.

Attempts to address the problem, or at least, locate its roots failed. Seems like some previously crawled pages are still in Google Search cache, but now (as of `1.9.0` release) they are missing.

Therefore, within this PR, the whole `/dart/` subtree is excluded from crawling altogether. Hopefully, it will enforce the cache cleanup.

In some future, we may re-enable the crawling for this part of the site. Most likely, it will make sense to do together with 2.0.0 release.