### PR TITLE
Use proper capitalization when referring to `spine-examples` in our helper sh script

### DIFF
--- a/sh
+++ b/sh
@@ -47,7 +47,7 @@ else
 			# ...
 			if [ $GIT_IS_AVAILABLE -eq 0 ];
 			then
-				printf "$BLUE Cloning$BOLD 'Spine-examples/hello'$BLUE into './hello'...                                        $NC\n"
+				printf "$BLUE Cloning$BOLD 'spine-examples/hello'$BLUE into './hello'...                                        $NC\n"
 				git clone https://github.com/spine-examples/hello.git
 		    else
 		    	printf "$BLUE $BOLD 'git'$BLUE is not available in your PATH. Please install it, and repeat the action.         $NC\n"


### PR DESCRIPTION
Previously, our sh helper script was printing the name of Spine's examples organisation as `Spine-examples`. This isn't exactly right.

This changeset updates the spelling to use a small `s`.