### PR TITLE
Fix the Core API links in the feature section

### DIFF
--- a/_includes/feature-section.html
+++ b/_includes/feature-section.html
@@ -47,11 +47,11 @@
             <div class="card-content-text">
                 <header class="feature-card-title">Clear API</header>
                 <p>Concepts from the DDD books, such as
-                    <code><a href="{{site.core_api_doc}}/server/io/spine/server/aggregate/Aggregate.html">Aggregate</a></code>,
-                    <code><a href="{{site.core_api_doc}}/server/io/spine/server/projection/Projection.html">Projection</a></code>,
-                    <code><a href="{{site.core_api_doc}}/server/io/spine/server/procman/ProcessManager.html">ProcessManager</a></code>,
-                    <code><a href="{{site.core_api_doc}}/server/io/spine/server/entity/Repository.html">Repository</a></code> are right in the code.
-                    Ever guessed how to cook a <code><a href="{{site.core_api_doc}}/server/io/spine/server/BoundedContext.html">BoundedContext</a></code>?
+                    <code><a href="{{site.core_api_doc}}/server/server/io.spine.server.aggregate/-aggregate/index.html">Aggregate</a></code>,
+                    <code><a href="{{site.core_api_doc}}/server/server/io.spine.server.projection/-projection/index.html">Projection</a></code>,
+                    <code><a href="{{site.core_api_doc}}/server/server/io.spine.server.procman/-process-manager/index.html">ProcessManager</a></code>,
+                    <code><a href="{{site.core_api_doc}}/server/server/io.spine.server.entity/-repository/index.html">Repository</a></code> are right in the code.
+                    Ever guessed how to cook a <code><a href="{{site.core_api_doc}}/server/server/io.spine.server/-bounded-context/index.html">BoundedContext</a></code>?
                     Guess no more!
                 </p>
             </div>


### PR DESCRIPTION
This PR updates the link format in the feature section on the Homepage.